### PR TITLE
[bugfix] ManyToManyField with through broken

### DIFF
--- a/django_dynamic_fixture/models.py
+++ b/django_dynamic_fixture/models.py
@@ -120,6 +120,11 @@ class ModelRelated(models.Model):
         verbose_name = 'Related'
 
 
+class ModelRelatedThrough(models.Model):
+    related = models.ForeignKey('ModelRelated')
+    relationship = models.ForeignKey('ModelWithRelationships')
+
+
 def default_fk_value():
     try:
         return ModelRelated.objects.get(id=1)
@@ -133,6 +138,7 @@ class ModelWithRelationships(models.Model):
     foreignkey = models.ForeignKey('ModelRelated', related_name='fk', null=True)
     onetoone = models.OneToOneField('ModelRelated', related_name='o2o', null=True)
     manytomany = models.ManyToManyField('ModelRelated', related_name='m2m')
+    manytomany_through = models.ManyToManyField('ModelRelated', related_name='m2m_through', through=ModelRelatedThrough)
 
     foreignkey_with_default = models.ForeignKey('ModelRelated', related_name='fk2', null=True, default=default_fk_value)
 

--- a/django_dynamic_fixture/tests/test_ddf.py
+++ b/django_dynamic_fixture/tests/test_ddf.py
@@ -245,6 +245,14 @@ class ManyToManyRelationshipTest(DDFTestCase):
     def test_invalid_many_to_many_configuration(self):
         self.assertRaises(InvalidManyToManyConfigurationError, self.ddf.get, ModelWithRelationships, manytomany='a')
 
+    def test_many_to_many_through(self):
+        b1 = self.ddf.get(ModelRelated, integer=1000)
+        b2 = self.ddf.get(ModelRelated, integer=1001)
+        instance = self.ddf.get(ModelWithRelationships, manytomany_through=[b1, b2])
+        self.assertEquals(2, instance.manytomany_through.all().count())
+        self.assertEquals(1000, instance.manytomany_through.all()[0].integer)
+        self.assertEquals(1001, instance.manytomany_through.all()[1].integer)
+
 
 class NewDealWithCyclicDependenciesTest(DDFTestCase):
     def test_new_create_by_default_only_1_lap_in_cycle(self):


### PR DESCRIPTION
I have a model `Foo` with the following field

```
users = models.ManyToManyField(User, through='Bar')
```

The test case below causes an empty array to be printed.

```
class FooTest(TestCase):

    def test_foo(self):
        user = G(User)
        obj = G(Foo, players=[player])
        print(obj.users.all())
```

Looking into `ddf.py`, I see `next_instance.save()` is called if the related manager has no `add` method, the assumption being that `through` must have been specified on the model.

The problem is that while the instance is saved correctly, the relationship is never created. For me this is solved by adding the following after `next_instance.save()`

```
through_model = manytomany_field.through
through_instance = DynamicFixture(data_fixture=self.data_fixture) \
    .get(through_model, **{
        manytomany_field.source_field_name: instance,
        manytomany_field.target_field_name: next_instance
    })
```

This uses the same fixture to create an instance of the `through` model, establishing the relationship. I see there are currently no tests for `through` on `ManyToManyField`. Was the behaviour I'm seeing intended, or is this a bug?
