### PR TITLE
Fix picking the value for a field when using grouped field choices

### DIFF
--- a/django_dynamic_fixture/ddf.py
+++ b/django_dynamic_fixture/ddf.py
@@ -328,7 +328,7 @@ class DynamicFixture(object):
             else:
                 data = field.default
         elif field_has_choices(field):
-            data = field.choices[0][0] # key of the first choice
+            data = field.flatchoices[0][0] # key of the first choice
         elif is_relationship_field(field):
             data = self._process_foreign_key(model_class, field, persist_dependencies)
         else:

--- a/django_dynamic_fixture/test_models.py
+++ b/django_dynamic_fixture/test_models.py
@@ -78,6 +78,7 @@ class ModelWithDefaultValues(models.Model):
     integer_with_default = models.IntegerField(null=True, default=3)
     string_with_choices = models.CharField(max_length=5, null=True, choices=(('a', 'A'), ('b', 'B')))
     string_with_choices_and_default = models.CharField(max_length=5, null=True, default='b', choices=(('a', 'A'), ('b', 'B')))
+    string_with_optgroup_choices = models.CharField(max_length=5, null=True, choices=(('group1', (('a', 'A'), ('b', 'B'))), ('group2', (('c', 'C'), ('d', 'D')))))
     foreign_key_with_default = models.ForeignKey(EmptyModel, null=True, default=None)
 
     class Meta:

--- a/django_dynamic_fixture/tests/test_ddf.py
+++ b/django_dynamic_fixture/tests/test_ddf.py
@@ -104,6 +104,10 @@ class NewFullFillAttributesWithDefaultDataTest(DDFTestCase):
         instance = self.ddf.new(ModelWithDefaultValues)
         self.assertEquals('b', instance.string_with_choices_and_default)
 
+    def test_fill_field_with_possible_optgroup_choices(self):
+        instance = self.ddf.new(ModelWithDefaultValues)
+        self.assertEquals('a', instance.string_with_optgroup_choices)
+
 
 class NewFullFillAttributesWithCustomDataTest(DDFTestCase):
     def test_fields_are_filled_with_custom_attributes(self):


### PR DESCRIPTION
If you have grouped the choices for a field, then the label of the first group is picked, rather than the first valid option. This change updates DynamicFixture to pick the first option from the flattened list of field options (i.e. field.flatchoices rather than field.choices)
