### PR TITLE
Fix generating fixtures for polymorphic models

### DIFF
--- a/django_dynamic_fixture/ddf.py
+++ b/django_dynamic_fixture/ddf.py
@@ -437,9 +437,18 @@ class DynamicFixture(object):
         instance = model_class()
         if not is_model_class(instance):
             raise InvalidModelError(get_unique_model_name(model_class))
+
+        try:
+            from polymorphic import PolymorphicModel
+            is_polymorphic = isinstance(instance, PolymorphicModel)
+        except ImportError:
+            # Django-polymorphic is not installed so the model can't be polymorphic.
+            is_polymorphic = False
+
         for field in get_fields_from_model(model_class):
             if is_key_field(field) and 'id' not in configuration: continue
             if field.name in self.ignore_fields: continue
+            if is_polymorphic and field.name == 'polymorphic_ctype': continue
             self.set_data_for_a_field(model_class, instance, field, persist_dependencies=persist_dependencies, **configuration)
         number_of_pending_fields = len(self.pending_fields)
         # For Copier fixtures: dealing with pending fields that need to receive values of another fields.

--- a/django_dynamic_fixture/models_test.py
+++ b/django_dynamic_fixture/models_test.py
@@ -5,6 +5,8 @@ from django.db import models
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
 
+from polymorphic import PolymorphicModel
+
 
 class EmptyModel(models.Model):
     pass
@@ -320,3 +322,8 @@ class ModelForSignals(models.Model):
 class ModelForSignals2(models.Model):
     class Meta:
         verbose_name = 'Signals 2'
+
+
+class ModelPolymorphic(PolymorphicModel):
+    class Meta:
+        verbose_name = 'Polymorphic Model'

--- a/django_dynamic_fixture/tests/test_ddf.py
+++ b/django_dynamic_fixture/tests/test_ddf.py
@@ -744,3 +744,9 @@ class SanityTest(DDFTestCase):
     def test_create_lots_of_models_to_verify_data_unicity_errors(self):
         for i in range(1000):
             self.ddf.get(ModelWithNumbers)
+
+
+class PolymorphicModelTest(DDFTestCase):
+    def test_create_polymorphic_model_and_retrieve(self):
+        p = self.ddf.get(ModelPolymorphic)
+        self.assertEqual([p], list(ModelPolymorphic.objects.all()))

--- a/django_dynamic_fixture/tests/test_django_helper.py
+++ b/django_dynamic_fixture/tests/test_django_helper.py
@@ -10,13 +10,13 @@ from django_dynamic_fixture.django_helper import *
 
 class DjangoHelperAppsTest(TestCase):
     def test_get_apps_must_return_all_installed_apps(self):
-        self.assertEquals(1, len(get_apps()))
+        self.assertEquals(2, len(get_apps()))
 
     def test_get_apps_may_be_filtered_by_app_names(self):
         self.assertEquals(1, len(get_apps(application_labels=['django_dynamic_fixture'])))
 
     def test_get_apps_may_ignore_some_apps(self):
-        self.assertEquals(0, len(get_apps(exclude_application_labels=['django_dynamic_fixture'])))
+        self.assertEquals(1, len(get_apps(exclude_application_labels=['django_dynamic_fixture'])))
 
     def test_app_name_must_be_valid(self):
         self.assertRaises(Exception, get_apps, application_labels=['x'])

--- a/settings.py
+++ b/settings.py
@@ -15,6 +15,7 @@ INSTALLED_APPS = (
     'django_coverage',
     'django_nose',
     'django_dynamic_fixture',
+    'django.contrib.contenttypes',
 )
 
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ setenv = VIRTUAL_ENV={envdir}
 
 deps =
     -r{toxinidir}/requirements.txt
+    django_polymorphic==0.5.6
 
 commands = {toxinidir}/runtests.py
 


### PR DESCRIPTION
If the model is a PolymorphicModel then it has a polymorphic_ctype field which
shouldn't be touched, changing it will cause the model not to be found by its
own querysets.
