### PR TITLE
Always honor attributes if given explicitly by user

### DIFF
--- a/django_dynamic_fixture/ddf.py
+++ b/django_dynamic_fixture/ddf.py
@@ -439,7 +439,7 @@ class DynamicFixture(object):
             raise InvalidModelError(get_unique_model_name(model_class))
         for field in get_fields_from_model(model_class):
             if is_key_field(field) and 'id' not in configuration: continue
-            if field.name in self.ignore_fields: continue
+            if field.name in self.ignore_fields and field.name not in self.kwargs: continue
             self.set_data_for_a_field(model_class, instance, field, persist_dependencies=persist_dependencies, **configuration)
         number_of_pending_fields = len(self.pending_fields)
         # For Copier fixtures: dealing with pending fields that need to receive values of another fields.

--- a/django_dynamic_fixture/tests/test_ddf.py
+++ b/django_dynamic_fixture/tests/test_ddf.py
@@ -164,6 +164,11 @@ class NewIgnoreFieldsInIgnoreListTest(DDFTestCase):
         instance = self.ddf.new(ModelForIgnoreList)
         self.assertNotEquals(None, instance.different_reference.nullable)
 
+    def test_ignore_fields_are_not_ignored_if_explicitely_given(self):
+        self.ddf = DynamicFixture(data_fixture, not_required=3, ignore_fields=['not_required', 'nullable'])
+        instance = self.ddf.new(ModelForIgnoreList)
+        self.assertEqual(3, instance.not_required)
+
 
 class NewAlsoCreatesRelatedObjectsTest(DDFTestCase):
     def test_new_fill_foreignkey_fields(self):


### PR DESCRIPTION
disregarding ignore_fields content.

It allows usage of django-dynamic-fixture like this:

``` python
assert settings.DDF_IGNORE_FIELDS == ['name']
instance = G(InstanceModel, name='foo')
assert instance.name == 'foo'
```

Because It is user decision and user should be able to override gloabal settings when it comes handy to do it.
