### PR TITLE
bugfix on models.py

### DIFF
--- a/django_dynamic_fixture/models.py
+++ b/django_dynamic_fixture/models.py
@@ -2,5 +2,5 @@ from django.conf import settings
 
 import_models = getattr(settings, 'IMPORT_DDF_MODELS', False)
 
-if settings.IMPORT_DDF_MODELS:
+if import_models:
     from django_dynamic_fixture.models_test import *


### PR DESCRIPTION
Avoid the AttributeError: 'Settings' object has no attribute 'IMPORT_DDF_MODELS' error
