### PR TITLE
Fix fixture generation for polymorphic models (including MTI subclasses).

### DIFF
--- a/django_dynamic_fixture/ddf.py
+++ b/django_dynamic_fixture/ddf.py
@@ -449,9 +449,16 @@ class DynamicFixture(object):
         instance = model_class()
         if not is_model_class(instance):
             raise InvalidModelError(get_unique_model_name(model_class))
+        try:
+            from polymorphic import PolymorphicModel
+            is_polymorphic = isinstance(instance, PolymorphicModel)
+        except ImportError:
+            # Django-polymorphic is not installed so the model can't be polymorphic.
+            is_polymorphic = False
         for field in get_fields_from_model(model_class):
             if is_key_field(field) and 'id' not in configuration: continue
             if field.name in self.ignore_fields and field.name not in self.kwargs: continue
+            if is_polymorphic and (field.name == 'polymorphic_ctype' or field.primary_key): continue
             self.set_data_for_a_field(model_class, instance, field, persist_dependencies=persist_dependencies, **configuration)
         number_of_pending_fields = len(self.pending_fields)
         # For Copier fixtures: dealing with pending fields that need to receive values of another fields.

--- a/django_dynamic_fixture/models_test.py
+++ b/django_dynamic_fixture/models_test.py
@@ -8,6 +8,8 @@ from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
 from django_dynamic_fixture.django_helper import django_greater_than
 
+from polymorphic import PolymorphicModel
+
 
 class EmptyModel(models.Model):
     pass
@@ -334,6 +336,16 @@ class ModelForSignals(models.Model):
 class ModelForSignals2(models.Model):
     class Meta:
         verbose_name = 'Signals 2'
+
+
+class ModelPolymorphic(PolymorphicModel):
+    class Meta:
+        verbose_name = 'Polymorphic Model'
+
+
+class ModelPolymorphic2(ModelPolymorphic):
+    class Meta:
+        verbose_name = 'Polymorphic Model 2'
 
 
 class ModelForFieldPlugins(models.Model):

--- a/django_dynamic_fixture/tests/test_ddf.py
+++ b/django_dynamic_fixture/tests/test_ddf.py
@@ -862,6 +862,16 @@ class SanityTest(DDFTestCase):
             self.ddf.get(ModelWithNumbers)
 
 
+class PolymorphicModelTest(DDFTestCase):
+    def test_create_polymorphic_model_and_retrieve(self):
+        p = self.ddf.get(ModelPolymorphic)
+        self.assertEqual([p], list(ModelPolymorphic.objects.all()))
+
+    def test_create_polymorphic_model_2_and_retrieve(self):
+        p = self.ddf.get(ModelPolymorphic2)
+        self.assertEqual([p], list(ModelPolymorphic2.objects.all()))
+
+
 class AvoidNameCollisionTest(DDFTestCase):
     def test_avoid_common_name_instance(self):
         self.ddf = DynamicFixture(data_fixture, fill_nullable_fields=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ django-json-field
 #psycopg2cffi # pypy2+ compatible
 
 geopy
+django_polymorphic

--- a/settings.py
+++ b/settings.py
@@ -62,6 +62,7 @@ INSTALLED_APPS += (
     'django_coverage',
     'django_nose',
     'django_dynamic_fixture',
+    'django.contrib.contenttypes',
 )
 
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'


### PR DESCRIPTION
If the model is a `PolymorphicModel` then it has a `polymorphic_ctype` field which shouldn't be touched. Changing it will cause the model not to be found by its own querysets.

MTI subclasses have a `OneToOneField` as their primary key, which should also not be touched.
