### PR TITLE
Update tox version and configuration.

### DIFF
--- a/django_dynamic_fixture/ddf.py
+++ b/django_dynamic_fixture/ddf.py
@@ -143,7 +143,7 @@ class Copier(object):
         self.expression = expression
 
     def __str__(self):
-        return u"C('%s')" % self.expression
+        return "C('%s')" % self.expression
 
     def immediate_field_name(self, instance):
         model_class = instance.__class__
@@ -244,7 +244,7 @@ class DynamicFixture(object):
         self.fields_to_disable_auto_now_add = []
 
     def __str__(self):
-        return u'F(%s)' % (u', '.join(u'%s=%s' % (key, value) for key, value in self.kwargs.items()))
+        return 'F(%s)' % (', '.join(six.text_type('%s=%s') % (key, value) for key, value in self.kwargs.items()))
 
     def __eq__(self, that):
         return self.kwargs == that.kwargs
@@ -458,7 +458,7 @@ class DynamicFixture(object):
             self.set_data_for_a_field(model_class, instance, field, persist_dependencies=persist_dependencies, **configuration)
             i += 1
             if i > 2 * number_of_pending_fields: # dealing with infinite loop too.
-                raise InvalidConfigurationError(get_unique_field_name(field), u'Cyclic dependency of Copiers.')
+                raise InvalidConfigurationError(get_unique_field_name(field), 'Cyclic dependency of Copiers.')
         if self.debug_mode:
             LOGGER.debug('<<< [%s] Instance created.' % get_unique_model_name(model_class))
         return instance

--- a/django_dynamic_fixture/fixture_algorithms/random_fixture.py
+++ b/django_dynamic_fixture/fixture_algorithms/random_fixture.py
@@ -15,7 +15,7 @@ from django_dynamic_fixture.ddf import DataFixture
 
 class RandomDataFixture(DataFixture):
     def random_string(self, n):
-        return u''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(n))
+        return six.text_type('').join(random.choice(string.ascii_uppercase + string.digits) for _ in range(n))
 
     # NUMBERS
     def integerfield_config(self, field, key, start=1, end=10 ** 6):
@@ -82,20 +82,20 @@ class RandomDataFixture(DataFixture):
 
     # FORMATTED STRINGS
     def emailfield_config(self, field, key):
-        return u'a%s@dynamicfixture.com' % self.random_string(10)
+        return six.text_type('a%s@dynamicfixture.com') % self.random_string(10)
 
     def urlfield_config(self, field, key):
-        return u'http://dynamicfixture%s.com' % self.random_string(10)
+        return six.text_type('http://dynamicfixture%s.com') % self.random_string(10)
 
     def ipaddressfield_config(self, field, key):
         a = random.randint(1, 255)
         b = random.randint(1, 255)
         c = random.randint(1, 255)
         d = random.randint(1, 255)
-        return u'%s.%s.%s.%s' % (a, b, c, d)
+        return six.text_type('%s.%s.%s.%s') % (a, b, c, d)
 
     def xmlfield_config(self, field, key):
-        return u'<a>%s</a>' % self.random_string(5)
+        return six.text_type('<a>%s</a>') % self.random_string(5)
 
     # FILES
     def filepathfield_config(self, field, key):

--- a/django_dynamic_fixture/fixture_algorithms/sequential_fixture.py
+++ b/django_dynamic_fixture/fixture_algorithms/sequential_fixture.py
@@ -116,10 +116,10 @@ class SequentialDataFixture(DataFixture):
 
     # FORMATTED STRINGS
     def emailfield_config(self, field, key):
-        return u'a%s@dynamicfixture.com' % self.get_value(field, key)
+        return six.text_type('a%s@dynamicfixture.com') % self.get_value(field, key)
 
     def urlfield_config(self, field, key):
-        return u'http://dynamicfixture%s.com' % self.get_value(field, key)
+        return six.text_type('http://dynamicfixture%s.com') % self.get_value(field, key)
 
     def ipaddressfield_config(self, field, key):
         # TODO: better workaround (this suppose ip field is not unique)
@@ -128,10 +128,10 @@ class SequentialDataFixture(DataFixture):
         b = '1'
         c = '1'
         d = data % 256
-        return u'%s.%s.%s.%s' % (a, b, c, str(d))
+        return six.text_type('%s.%s.%s.%s') % (a, b, c, str(d))
 
     def xmlfield_config(self, field, key):
-        return u'<a>%s</a>' % self.get_value(field, key)
+        return six.text_type('<a>%s</a>') % self.get_value(field, key)
 
     # FILES
     def filepathfield_config(self, field, key):

--- a/django_dynamic_fixture/fixture_algorithms/unique_random_fixture.py
+++ b/django_dynamic_fixture/fixture_algorithms/unique_random_fixture.py
@@ -43,7 +43,7 @@ class UniqueRandomDataFixture(DataFixture):
         counter = six.text_type(self.get_counter(field, key))
         length = n or self.DEFAULT_LENGTH
         result = counter
-        result += u''.join(
+        result += six.text_type('').join(
             random.choice(string.ascii_letters)
             for _ in xrange(length - len(counter))
         )
@@ -142,10 +142,10 @@ class UniqueRandomDataFixture(DataFixture):
 
     # FORMATTED STRINGS
     def emailfield_config(self, field, key):
-        return u'a%s@dynamicfixture.com' % self.random_string(field, key)
+        return six.text_type('a%s@dynamicfixture.com') % self.random_string(field, key)
 
     def urlfield_config(self, field, key):
-        return u'http://dynamicfixture%s.com' % self.random_string(field, key)
+        return six.text_type('http://dynamicfixture%s.com') % self.random_string(field, key)
 
     def ipaddressfield_config(self, field, key):
         MAX_IP = 2 ** 32 - 1
@@ -155,7 +155,7 @@ class UniqueRandomDataFixture(DataFixture):
         return six.text_type(socket.inet_ntoa(struct.pack('!L', integer)))
 
     def xmlfield_config(self, field, key):
-        return u'<a>%s</a>' % self.random_string(field, key)
+        return six.text_type('<a>%s</a>') % self.random_string(field, key)
 
     # FILES
     def filepathfield_config(self, field, key):

--- a/django_dynamic_fixture/tests/test_ddf.py
+++ b/django_dynamic_fixture/tests/test_ddf.py
@@ -783,7 +783,7 @@ class ExceptionsLayoutMessagesTest(DDFTestCase):
             error_msg2 = 'NOT NULL constraint failed: django_dynamic_fixture_modelforignorelist.required'
             template1 = "('%s', IntegrityError('%s',))" % (model_msg, error_msg)
             template2 = "('%s', IntegrityError('%s',))" % (model_msg, error_msg2) # py34
-            template3 = "('%s', IntegrityError(u'%s',))" % (model_msg, error_msg) # pypy
+            template3 = "('%s', IntegrityError(u'%s',))" % (model_msg, error_msg2) # pypy
             self.assertEquals(str(e) in [template1, template2, template3], True, msg=str(e))
 
     def test_InvalidConfigurationError(self):

--- a/django_dynamic_fixture/tests/test_ddf.py
+++ b/django_dynamic_fixture/tests/test_ddf.py
@@ -783,8 +783,9 @@ class ExceptionsLayoutMessagesTest(DDFTestCase):
             error_msg2 = 'NOT NULL constraint failed: django_dynamic_fixture_modelforignorelist.required'
             template1 = "('%s', IntegrityError('%s',))" % (model_msg, error_msg)
             template2 = "('%s', IntegrityError('%s',))" % (model_msg, error_msg2) # py34
-            template3 = "('%s', IntegrityError(u'%s',))" % (model_msg, error_msg2) # pypy
-            self.assertEquals(str(e) in [template1, template2, template3], True, msg=str(e))
+            template3 = "('%s', IntegrityError(u'%s',))" % (model_msg, error_msg) # pypy
+            template4 = "('%s', IntegrityError(u'%s',))" % (model_msg, error_msg2) # pypy
+            self.assertEquals(str(e) in [template1, template2, template3, template4], True, msg=str(e))
 
     def test_InvalidConfigurationError(self):
         try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ django-coverage==1.2.4
 nose==1.3.0
 django-nose==1.2
 nose-progressive
-tox==1.7.0
+tox>=1.8.0
 
 coveralls
 python-coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,10 @@
 
 [tox]
 envlist =
-    django14-py{26,27},
-    django16-py{26,27,32,33},
-    django17-py{27,32,33,34},
+	django{12,13}-py{26,27,py},
+    django14-py{26,27,py},
+    django{15,16}-py{26,27,32,33,34,py},
+    django17-py{27,32,33,34,py},
 
 
 [testenv]
@@ -25,10 +26,14 @@ basepython=
     py32: python3.2
     py33: python3.3
     py34: python3.4
+    pypy: pypy
 
 deps =
     -r{toxinidir}/requirements.txt
+    django12: django>=1.2,<1.3
+    django13: django>=1.3,<1.4
     django14: django>=1.4,<1.5
+    django15: django>=1.5,<1.6
     django16: django>=1.6,<1.7
     django17: django>=1.7,<1.8
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,105 +5,31 @@
 
 [tox]
 envlist =
-    py27-django12,
-    py27-django13,
-    py27-django14,
-    py27-django15,
-    py27-django16,
-    py33-django16,
-    py27-django17,
-    py33-django17,
-    py34-django17,
-    pypy-django16,
-    pypy-django17
+    django14-py{26,27},
+    django16-py{26,27,32,33},
+    django17-py{27,32,33,34},
 
 
 [testenv]
-setenv = VIRTUAL_ENV={envdir}
-         NOSE_WITH_OPENSTACK=1
-         NOSE_OPENSTACK_COLOR=1
-         NOSE_OPENSTACK_RED=0.05
-         NOSE_OPENSTACK_YELLOW=0.025
-         NOSE_OPENSTACK_SHOW_ELAPSED=1
+setenv =
+    VIRTUAL_ENV={envdir}
+    NOSE_WITH_OPENSTACK=1
+    NOSE_OPENSTACK_COLOR=1
+    NOSE_OPENSTACK_RED=0.05
+    NOSE_OPENSTACK_YELLOW=0.025
+    NOSE_OPENSTACK_SHOW_ELAPSED=1
+
+basepython=
+    py26: python2.6
+    py27: python2.7
+    py32: python3.2
+    py33: python3.3
+    py34: python3.4
 
 deps =
     -r{toxinidir}/requirements.txt
+    django14: django>=1.4,<1.5
+    django16: django>=1.6,<1.7
+    django17: django>=1.7,<1.8
 
 commands = {toxinidir}/runtests.py
-
-
-# py27 ===========================
-
-[testenv:py27-django12]
-basepython=python2.7
-deps=
-    {[testenv]deps}
-    django>=1.2,<1.3
-
-
-[testenv:py27-django13]
-basepython=python2.7
-deps=
-    {[testenv]deps}
-    django>=1.3,<1.4
-
-[testenv:py27-django14]
-basepython=python2.7
-deps=
-    {[testenv]deps}
-    django>=1.4,<1.5
-
-[testenv:py27-django15]
-basepython=python2.7
-deps=
-    {[testenv]deps}
-    django>=1.5,<1.6
-
-[testenv:py27-django16]
-basepython=python2.7
-deps=
-    {[testenv]deps}
-    django>=1.6,<1.7
-
-[testenv:py27-django17]
-basepython=python2.7
-deps=
-    {[testenv]deps}
-    django>=1.7,<1.8
-
-# pypy ===========================
-
-[testenv:pypy-django16]
-basepython=pypy
-deps=
-    {[testenv]deps}
-    django==1.6
-
-[testenv:pypy-django17]
-basepython=pypy
-deps=
-    {[testenv]deps}
-    django==1.7
-
-# py33 ===========================
-
-[testenv:py33-django16]
-basepython=python3.3
-deps=
-    {[testenv]deps}
-    django>=1.6,<1.7
-
-[testenv:py33-django17]
-basepython=python3.3
-deps=
-    {[testenv]deps}
-    django>=1.7,<1.8
-
-
-# py34 ===========================
-
-[testenv:py34-django17]
-basepython=python3.4
-deps=
-    {[testenv]deps}
-    django>=1.7,<1.8

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 envlist =
-	django{12,13}-py{26,27,py},
+    django{12,13}-py{26,27,py},
     django14-py{26,27,py},
     django{15,16}-py{26,27,32,33,34,py},
     django17-py{27,32,33,34,py},


### PR DESCRIPTION
* Use tox 1.8+ so we can use generative envlist and conditional deps.
* Don't test older unsupported versions of Django.
* Do test older supported versions of Python, according to Django release notes, except for django14-py25 because Python 2.5 is not supported by tox since 1.7.0.
* Fix Python 3.2 `u''` syntax errors.