### PR TITLE
Don't swallow exceptions when saving polymorphic models.

### DIFF
--- a/django_dynamic_fixture/ddf.py
+++ b/django_dynamic_fixture/ddf.py
@@ -449,9 +449,16 @@ class DynamicFixture(object):
         instance = model_class()
         if not is_model_class(instance):
             raise InvalidModelError(get_unique_model_name(model_class))
+        try:
+            from polymorphic import PolymorphicModel
+            is_polymorphic = isinstance(instance, PolymorphicModel)
+        except ImportError:
+            # Django-polymorphic is not installed so the model can't be polymorphic.
+            is_polymorphic = False
         for field in get_fields_from_model(model_class):
             if is_key_field(field) and 'id' not in configuration: continue
             if field.name in self.ignore_fields and field.name not in self.kwargs: continue
+            if is_polymorphic and (field.name == 'polymorphic_ctype' or field.primary_key): continue
             self.set_data_for_a_field(model_class, instance, field, persist_dependencies=persist_dependencies, **configuration)
         number_of_pending_fields = len(self.pending_fields)
         # For Copier fixtures: dealing with pending fields that need to receive values of another fields.

--- a/django_dynamic_fixture/django_helper.py
+++ b/django_dynamic_fixture/django_helper.py
@@ -198,7 +198,11 @@ def print_field_values_of_a_model(model_instance):
     else:
         print('\n:: Model %s (%s)' % (get_unique_model_name(model_instance.__class__), model_instance.pk))
         for field in get_fields_from_model(model_instance.__class__):
-            print('%s: %s' % (field.name, getattr(model_instance, field.name)))
+            try:
+                value = getattr(model_instance, field.name)
+            except Exception as e:
+                value = repr(e)
+            print('%s: %s' % (field.name, value))
         if model_instance.pk is not None:
             for field in get_many_to_many_fields_from_model(model_instance.__class__):
                 print('%s: %s' % (field.name, getattr(model_instance, field.name).all()))

--- a/django_dynamic_fixture/models_test.py
+++ b/django_dynamic_fixture/models_test.py
@@ -348,6 +348,14 @@ class ModelPolymorphic2(ModelPolymorphic):
         verbose_name = 'Polymorphic Model 2'
 
 
+class ModelPolymorphic3(ModelPolymorphic):
+    class CannotSave(Exception):
+        pass
+
+    def save(self):
+        raise self.CannotSave
+
+
 class ModelForFieldPlugins(models.Model):
     # aaa = CustomDjangoField(null=False) # defined in settings.py
     # bbb = models.IntegerField(null=False)

--- a/django_dynamic_fixture/models_test.py
+++ b/django_dynamic_fixture/models_test.py
@@ -8,6 +8,8 @@ from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
 from django_dynamic_fixture.django_helper import django_greater_than
 
+from polymorphic import PolymorphicModel
+
 
 class EmptyModel(models.Model):
     pass
@@ -334,6 +336,16 @@ class ModelForSignals(models.Model):
 class ModelForSignals2(models.Model):
     class Meta:
         verbose_name = 'Signals 2'
+
+
+class ModelPolymorphic(PolymorphicModel):
+    class Meta:
+        verbose_name = 'Polymorphic Model'
+
+
+class ModelPolymorphic2(ModelPolymorphic):
+    class Meta:
+        verbose_name = 'Polymorphic Model 2'
 
 
 class ModelForFieldPlugins(models.Model):

--- a/django_dynamic_fixture/tests/test_ddf.py
+++ b/django_dynamic_fixture/tests/test_ddf.py
@@ -862,6 +862,16 @@ class SanityTest(DDFTestCase):
             self.ddf.get(ModelWithNumbers)
 
 
+class PolymorphicModelTest(DDFTestCase):
+    def test_create_polymorphic_model_and_retrieve(self):
+        p = self.ddf.get(ModelPolymorphic)
+        self.assertEqual([p], list(ModelPolymorphic.objects.all()))
+
+    def test_create_polymorphic_model_2_and_retrieve(self):
+        p = self.ddf.get(ModelPolymorphic2)
+        self.assertEqual([p], list(ModelPolymorphic2.objects.all()))
+
+
 class AvoidNameCollisionTest(DDFTestCase):
     def test_avoid_common_name_instance(self):
         self.ddf = DynamicFixture(data_fixture, fill_nullable_fields=False)

--- a/django_dynamic_fixture/tests/test_ddf.py
+++ b/django_dynamic_fixture/tests/test_ddf.py
@@ -871,6 +871,10 @@ class PolymorphicModelTest(DDFTestCase):
         p = self.ddf.get(ModelPolymorphic2)
         self.assertEqual([p], list(ModelPolymorphic2.objects.all()))
 
+    def test_cannot_save(self):
+        with self.assertRaises(BadDataError):
+            self.ddf.get(ModelPolymorphic3)
+
 
 class AvoidNameCollisionTest(DDFTestCase):
     def test_avoid_common_name_instance(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ django-json-field
 #psycopg2cffi # pypy2+ compatible
 
 geopy
+django_polymorphic

--- a/settings.py
+++ b/settings.py
@@ -62,6 +62,7 @@ INSTALLED_APPS += (
     'django_coverage',
     'django_nose',
     'django_dynamic_fixture',
+    'django.contrib.contenttypes',
 )
 
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'


### PR DESCRIPTION
If an exception is raised in the `save()` method of a polymorphic model,
DDF tries to print all the field values for the model which will in turn
raise a `DoesNotExist` exception on the `*_ptr` field, that masks the
real exception.

This commit catches and displays the `repr()` of exceptions raised in
when displaying field values in the `print_field_values_of_a_model()`
method, which allows the real exception to exposed via `BadDataError`.

It might be more appropriate to just not display field values for
`*_ptr` fields, though, as they are not set directly by the user.
