### PR TITLE
Prepare for deprecation of django.utils.importlib in Django 1.9

### DIFF
--- a/django_dynamic_fixture/ddf.py
+++ b/django_dynamic_fixture/ddf.py
@@ -7,7 +7,11 @@ import six
 
 from django.core.files import File
 from django.db.models import Field
-from django.utils.importlib import import_module
+
+try:
+    from importlib import import_module
+except ImportError:
+    from django.utils.importlib import import_module
 
 from django_dynamic_fixture.django_helper import get_related_model, \
     field_has_choices, field_has_default_value, get_fields_from_model, \

--- a/django_dynamic_fixture/global_settings.py
+++ b/django_dynamic_fixture/global_settings.py
@@ -8,7 +8,10 @@ import sys
 
 from django.conf import settings
 from django.core.urlresolvers import get_mod_func
-from django.utils.importlib import import_module
+try:
+    from importlib import import_module
+except ImportError:
+    from django.utils.importlib import import_module
 import six
 
 from django_dynamic_fixture.fixture_algorithms.sequential_fixture import SequentialDataFixture, StaticSequentialDataFixture, GlobalSequentialDataFixture


### PR DESCRIPTION
Django.utils.importlib will be removed in Django 1.9