### PR TITLE
Reinstate tests for supported Django & Python versions, and fix tests…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,17 +9,31 @@ script:
   - tox
 
 env:
-  - TOXENV=py27-django14
-  - TOXENV=py27-django15
-  - TOXENV=py27-django16
-  - TOXENV=py27-django17
-  - TOXENV=py27-django18
-  - TOXENV=py33-django17
-  - TOXENV=py33-django18
-  - TOXENV=py34-django17
-  - TOXENV=py34-django18
-  - TOXENV=pypy-django17
-  - TOXENV=pypy-django18
+  - TOXENV=django14-py26
+  - TOXENV=django14-py27
+  - TOXENV=django14-pypy
+  - TOXENV=django15-py26
+  - TOXENV=django15-py27
+  - TOXENV=django15-py32
+  - TOXENV=django15-py33
+  - TOXENV=django15-py34
+  - TOXENV=django15-pypy
+  - TOXENV=django16-py26
+  - TOXENV=django16-py27
+  - TOXENV=django16-py32
+  - TOXENV=django16-py33
+  - TOXENV=django16-py34
+  - TOXENV=django16-pypy
+  - TOXENV=django17-py27
+  - TOXENV=django17-py32
+  - TOXENV=django17-py33
+  - TOXENV=django17-py34
+  - TOXENV=django17-pypy
+  - TOXENV=django18-py27
+  - TOXENV=django18-py32
+  - TOXENV=django18-py33
+  - TOXENV=django18-py34
+  - TOXENV=django18-pypy
 
 after_success:
   - coveralls

--- a/django_dynamic_fixture/ddf.py
+++ b/django_dynamic_fixture/ddf.py
@@ -147,7 +147,7 @@ class Copier(object):
         self.expression = expression
 
     def __str__(self):
-        return u"C('%s')" % self.expression
+        return "C('%s')" % self.expression
 
     def immediate_field_name(self, instance):
         model_class = instance.__class__
@@ -248,7 +248,7 @@ class DynamicFixture(object):
         self.fields_to_disable_auto_now_add = []
 
     def __str__(self):
-        return u'F(%s)' % (u', '.join(u'%s=%s' % (key, value) for key, value in self.kwargs.items()))
+        return 'F(%s)' % (', '.join(six.text_type('%s=%s') % (key, value) for key, value in self.kwargs.items()))
 
     def __eq__(self, that):
         return self.kwargs == that.kwargs
@@ -462,7 +462,7 @@ class DynamicFixture(object):
             self.set_data_for_a_field(model_class, instance, field, persist_dependencies=persist_dependencies, **configuration)
             i += 1
             if i > 2 * number_of_pending_fields: # dealing with infinite loop too.
-                raise InvalidConfigurationError(get_unique_field_name(field), u'Cyclic dependency of Copiers.')
+                raise InvalidConfigurationError(get_unique_field_name(field), 'Cyclic dependency of Copiers.')
         if self.debug_mode:
             LOGGER.debug('<<< [%s] Instance created.' % get_unique_model_name(model_class))
         return instance

--- a/django_dynamic_fixture/fixture_algorithms/random_fixture.py
+++ b/django_dynamic_fixture/fixture_algorithms/random_fixture.py
@@ -20,7 +20,7 @@ from django_dynamic_fixture.fixture_algorithms.default_fixture import BaseDataFi
 
 class RandomDataFixture(BaseDataFixture, GeoDjangoDataFixture):
     def random_string(self, n):
-        return u''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(n))
+        return six.text_type('').join(random.choice(string.ascii_uppercase + string.digits) for _ in range(n))
 
     # NUMBERS
     def integerfield_config(self, field, key, start=1, end=10 ** 6):
@@ -87,20 +87,20 @@ class RandomDataFixture(BaseDataFixture, GeoDjangoDataFixture):
 
     # FORMATTED STRINGS
     def emailfield_config(self, field, key):
-        return u'a%s@dynamicfixture.com' % self.random_string(10)
+        return six.text_type('a%s@dynamicfixture.com') % self.random_string(10)
 
     def urlfield_config(self, field, key):
-        return u'http://dynamicfixture%s.com' % self.random_string(10)
+        return six.text_type('http://dynamicfixture%s.com') % self.random_string(10)
 
     def ipaddressfield_config(self, field, key):
         a = random.randint(1, 255)
         b = random.randint(1, 255)
         c = random.randint(1, 255)
         d = random.randint(1, 255)
-        return u'%s.%s.%s.%s' % (a, b, c, d)
+        return six.text_type('%s.%s.%s.%s') % (a, b, c, d)
 
     def xmlfield_config(self, field, key):
-        return u'<a>%s</a>' % self.random_string(5)
+        return six.text_type('<a>%s</a>') % self.random_string(5)
 
     # FILES
     def filepathfield_config(self, field, key):

--- a/django_dynamic_fixture/fixture_algorithms/sequential_fixture.py
+++ b/django_dynamic_fixture/fixture_algorithms/sequential_fixture.py
@@ -120,10 +120,10 @@ class SequentialDataFixture(BaseDataFixture, GeoDjangoDataFixture):
 
     # FORMATTED STRINGS
     def emailfield_config(self, field, key):
-        return u'a%s@dynamicfixture.com' % self.get_value(field, key)
+        return six.text_type('a%s@dynamicfixture.com') % self.get_value(field, key)
 
     def urlfield_config(self, field, key):
-        return u'http://dynamicfixture%s.com' % self.get_value(field, key)
+        return six.text_type('http://dynamicfixture%s.com') % self.get_value(field, key)
 
     def ipaddressfield_config(self, field, key):
         # TODO: better workaround (this suppose ip field is not unique)
@@ -132,10 +132,10 @@ class SequentialDataFixture(BaseDataFixture, GeoDjangoDataFixture):
         b = '1'
         c = '1'
         d = data % 256
-        return u'%s.%s.%s.%s' % (a, b, c, str(d))
+        return six.text_type('%s.%s.%s.%s') % (a, b, c, str(d))
 
     def xmlfield_config(self, field, key):
-        return u'<a>%s</a>' % self.get_value(field, key)
+        return six.text_type('<a>%s</a>') % self.get_value(field, key)
 
     # FILES
     def filepathfield_config(self, field, key):

--- a/django_dynamic_fixture/fixture_algorithms/unique_random_fixture.py
+++ b/django_dynamic_fixture/fixture_algorithms/unique_random_fixture.py
@@ -45,7 +45,7 @@ class UniqueRandomDataFixture(BaseDataFixture, GeoDjangoDataFixture):
         counter = six.text_type(self.get_counter(field, key))
         length = n or self.DEFAULT_LENGTH
         result = counter
-        result += u''.join(
+        result += six.text_type('').join(
             random.choice(string.ascii_letters)
             for _ in xrange(length - len(counter))
         )
@@ -144,10 +144,10 @@ class UniqueRandomDataFixture(BaseDataFixture, GeoDjangoDataFixture):
 
     # FORMATTED STRINGS
     def emailfield_config(self, field, key):
-        return u'a%s@dynamicfixture.com' % self.random_string(field, key)
+        return six.text_type('a%s@dynamicfixture.com') % self.random_string(field, key)
 
     def urlfield_config(self, field, key):
-        return u'http://dynamicfixture%s.com' % self.random_string(field, key)
+        return six.text_type('http://dynamicfixture%s.com') % self.random_string(field, key)
 
     def ipaddressfield_config(self, field, key):
         MAX_IP = 2 ** 32 - 1
@@ -157,7 +157,7 @@ class UniqueRandomDataFixture(BaseDataFixture, GeoDjangoDataFixture):
         return six.text_type(socket.inet_ntoa(struct.pack('!L', integer)))
 
     def xmlfield_config(self, field, key):
-        return u'<a>%s</a>' % self.random_string(field, key)
+        return six.text_type('<a>%s</a>') % self.random_string(field, key)
 
     # FILES
     def filepathfield_config(self, field, key):

--- a/django_dynamic_fixture/tests/test_ddf.py
+++ b/django_dynamic_fixture/tests/test_ddf.py
@@ -818,10 +818,8 @@ class ExceptionsLayoutMessagesTest(DDFTestCase):
             template1 = "('%s', IntegrityError('%s',))" % (model_msg, error_msg)
             template2 = "('%s', IntegrityError('%s',))" % (model_msg, error_msg2) # py34
             template3 = "('%s', IntegrityError(u'%s',))" % (model_msg, error_msg) # pypy
-            try:
-                self.assertEquals(str(e) in [template1, template2, template3], True, msg=str(e))
-            except AssertionError:
-                pass # It is ok to have a different template
+            template4 = "('%s', IntegrityError(u'%s',))" % (model_msg, error_msg2) # pypy
+            self.assertEquals(str(e) in [template1, template2, template3, template4], True, msg=str(e))
 
 
     def test_InvalidConfigurationError(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,8 @@
 [tox]
 envlist =
-    django14-py{27},
-    django15-py{27},
-    django16-py{27,33},
-    django17-py{27,33,34,py},
-    django18-py{27,33,34,py},
+    django14-py{26,27,py},
+    django{15,16}-py{26,27,32,33,34,py},
+    django{17,18}-py{27,32,33,34,py},
 
 [testenv]
 setenv =
@@ -16,7 +14,9 @@ setenv =
     NOSE_OPENSTACK_SHOW_ELAPSED=1
 
 basepython=
+    py26: python2.6
     py27: python2.7
+    py32: python3.2
     py33: python3.3
     py34: python3.4
     pypy: pypy


### PR DESCRIPTION
… for Python 3.2

Django 1.5 and 1.6 were not yet removed, even though they are not officially
supported anymore. Django 1.4 is also due to lose official support soon.

We should remove them from the envlist when it becomes to a burden to maintain
them or we want to cut down the number of environments being tested.

Removed the `except AssertionError` block in `test_ddf.py` at line 820 (but
kept the test). There's no point in running the tests if we are handling the
resulting AssertionError when the test fails.