### PR TITLE
Support for GenericForeignKey

### DIFF
--- a/django_dynamic_fixture/models_test.py
+++ b/django_dynamic_fixture/models_test.py
@@ -3,6 +3,8 @@
 
 import django
 from django.conf import settings
+from django.contrib.contenttypes.fields import GenericForeignKey
+from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
@@ -387,3 +389,9 @@ try:
         json_field1 = JSONField2()
 except ImportError:
     pass
+
+
+class ModelWithGenericForeignKey(models.Model):
+    owner_type = models.ForeignKey(ContentType)
+    owner_id = models.PositiveIntegerField()
+    owner = GenericForeignKey('owner_type', 'owner_id')

--- a/django_dynamic_fixture/tests/test_ddf.py
+++ b/django_dynamic_fixture/tests/test_ddf.py
@@ -901,3 +901,15 @@ class AvoidNameCollisionTest(DDFTestCase):
 
         instance = self.ddf.get(ModelWithCommonNames, field=6)
         self.assertEquals(6, instance.field)
+
+
+class GenericForeignKeyTest(DDFTestCase):
+    def test_set_generic_foreign_key(self):
+        owner = self.ddf.get(ModelWithDefaultValues)
+        ctype = ContentType.objects.get_for_model(owner)
+
+        instance = self.ddf.get(ModelWithGenericForeignKey, owner=owner)
+
+        self.assertIsInstance(instance.owner_type, ctype.__class__)
+        self.assertEqual(instance.owner_type, ctype)
+        self.assertEqual(instance.owner, owner)

--- a/settings.py
+++ b/settings.py
@@ -52,7 +52,9 @@ DATABASES = {
 SECRET_KEY = 'ddf-secret-key'
 
 
-INSTALLED_APPS = ()
+INSTALLED_APPS = (
+    'django.contrib.contenttypes',
+)
 
 if DDF_TEST_GEODJANGO:
     INSTALLED_APPS += ('django.contrib.gis',)


### PR DESCRIPTION
I'd like to propose better support for GenericForeignKeys.

I'd like to do the following;

```python
owner = G(ModelWithDefaultValues)
G(ModelWithGenericForeignKey, owner=owner)
```

This would automatically set the `owner_type` and `owner_id`.

I've added a very basic failing test which could probably be expanded upon.

In terms of actual support in DDF I have not implemented this, however I'd be willing to attempt it if it's something the core devs believe should be a feature.