### PR TITLE
Add support for django-pgfields' UUIDField

### DIFF
--- a/django_dynamic_fixture/fixture_algorithms/random_fixture.py
+++ b/django_dynamic_fixture/fixture_algorithms/random_fixture.py
@@ -112,3 +112,8 @@ class RandomDataFixture(BaseDataFixture, GeoDjangoDataFixture):
 
     def imagefield_config(self, field, key):
         return self.random_string(10)
+
+    # django-pgfields
+    def uuidfield_config(self, field, key):
+        from uuid import uuid4
+        return uuid4()

--- a/django_dynamic_fixture/fixture_algorithms/sequential_fixture.py
+++ b/django_dynamic_fixture/fixture_algorithms/sequential_fixture.py
@@ -148,6 +148,11 @@ class SequentialDataFixture(BaseDataFixture, GeoDjangoDataFixture):
     def imagefield_config(self, field, key):
         return six.text_type(self.get_value(field, key))
 
+    # django-pgfields
+    def uuidfield_config(self, field, key):
+        from uuid import uuid4
+        return uuid4()
+
 
 class GlobalSequentialDataFixture(SequentialDataFixture):
     def get_value(self, field, key):

--- a/django_dynamic_fixture/fixture_algorithms/unique_random_fixture.py
+++ b/django_dynamic_fixture/fixture_algorithms/unique_random_fixture.py
@@ -169,3 +169,8 @@ class UniqueRandomDataFixture(BaseDataFixture, GeoDjangoDataFixture):
 
     def imagefield_config(self, field, key):
         return self.random_string(field, key)
+
+    # django-pgfields
+    def uuidfield_config(self, field, key):
+        from uuid import uuid4
+        return uuid4()


### PR DESCRIPTION
This adds support for the generating a UUIDField from django-pgfields. See: https://django-pgfields.readthedocs.org/en/latest/fields.html#uuid-field
