### PR TITLE
make ForeignKey defaults that are ids work

### DIFF
--- a/django_dynamic_fixture/ddf.py
+++ b/django_dynamic_fixture/ddf.py
@@ -380,7 +380,13 @@ class DynamicFixture(object):
         else:
             if self.debug_mode:
                 LOGGER.debug('%s.%s = %s' % (get_unique_model_name(model_class), __field.name, data))
-            setattr(__instance, __field.name, data) # Model.field = data
+            try:
+                setattr(__instance, __field.name, data) # Model.field = data
+            except ValueError:
+                if is_relationship_field(__field):
+                    setattr(__instance, "%s_id" % __field.name, data) # Model.field = data
+                else:
+                    raise
         self.fields_processed.append(__field.name)
 
     def _validate_kwargs(self, model_class, kwargs):

--- a/django_dynamic_fixture/models_test.py
+++ b/django_dynamic_fixture/models_test.py
@@ -146,6 +146,10 @@ def default_fk_value():
         return ModelRelated.objects.all()[0]
 
 
+def default_fk_id():
+    return default_fk_value().pk
+
+
 class ModelWithRelationships(models.Model):
     # relationship
     selfforeignkey = models.ForeignKey('self', null=True)
@@ -155,6 +159,7 @@ class ModelWithRelationships(models.Model):
     manytomany_through = models.ManyToManyField('ModelRelated', related_name='m2m_through', through=ModelRelatedThrough)
 
     foreignkey_with_default = models.ForeignKey('ModelRelated', related_name='fk2', null=True, default=default_fk_value)
+    foreignkey_with_id_default = models.ForeignKey('ModelRelated', related_name='fk2', null=True, default=default_fk_id)
 
     integer = models.IntegerField(null=True)
     integer_b = models.IntegerField(null=True)

--- a/django_dynamic_fixture/tests/test_ddf.py
+++ b/django_dynamic_fixture/tests/test_ddf.py
@@ -274,6 +274,10 @@ class NewAlsoCreatesRelatedObjectsTest(DDFTestCase):
         instance = self.ddf.new(ModelWithRelationships)
         self.assertTrue(isinstance(instance.foreignkey_with_default, ModelRelated), msg=str(type(instance.foreignkey_with_default)))
 
+    def test_new_deal_with_id_default_values(self):
+        instance = self.ddf.new(ModelWithRelationships)
+        self.assertTrue(isinstance(instance.foreignkey_with_id_default, ModelRelated), msg=str(type(instance.foreignkey_with_default)))
+
 #        TODO
 #    def test_new_fill_genericrelations_fields(self):
 #        instance = self.ddf.new(ModelWithRelationships)


### PR DESCRIPTION
Default values for fields that map to model instances should be the
field they reference. See https://github.com/django/django/blob/b60375d4bbb848af7950379e2f35a1a65f7a2591/docs/ref/models/fields.txt#L223