### PR TITLE
Django 1.9 support

### DIFF
--- a/django_dynamic_fixture/tests/test_django_helper.py
+++ b/django_dynamic_fixture/tests/test_django_helper.py
@@ -25,7 +25,7 @@ class DjangoHelperAppsTest(TestCase):
         self.assertRaises(Exception, get_apps, exclude_application_labels=['x'])
 
     def test_get_app_name_must(self):
-        ddf = get_apps(application_labels=['django_dynamic_fixture'])[0]
+        import django_dynamic_fixture.models as ddf
         self.assertEquals('django_dynamic_fixture', get_app_name(ddf))
 
     def test_get_models_of_an_app_must(self):

--- a/runtests.py
+++ b/runtests.py
@@ -16,6 +16,8 @@ from django.conf import settings
 if not settings.configured:
     os.environ['DJANGO_SETTINGS_MODULE'] = 'settings'
 
+django.setup()
+
 from django_nose import NoseTestSuiteRunner
 
 # Django-Nose must import test_models to avoid 'no such table' problem

--- a/runtests.py
+++ b/runtests.py
@@ -16,7 +16,8 @@ from django.conf import settings
 if not settings.configured:
     os.environ['DJANGO_SETTINGS_MODULE'] = 'settings'
 
-django.setup()
+if django.VERSION >= (1, 7):
+    django.setup()
 
 from django_nose import NoseTestSuiteRunner
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist =
     django14-py{26,27,py},
     django{15,16}-py{26,27,32,33,34,py},
     django{17,18}-py{27,32,33,34,py},
+    django{19}-py{27,34,py},
 
 [testenv]
 setenv =
@@ -28,5 +29,6 @@ deps =
     django16: django>=1.6,<1.7
     django17: django>=1.7,<1.8
     django18: django>=1.8,<1.9
+    django19: django>=1.9,<1.10
 
 commands = {toxinidir}/runtests.py


### PR DESCRIPTION
Adding support for Django 1.9.

Django 1.9 released yesterday. It would be nice if DDF could support it, however slight changes are required. Here is a patch to make the test suite run against Django 1.9