### PR TITLE
Add support for ? and * wildcards in ignored field values

### DIFF
--- a/docs/source/data.rst
+++ b/docs/source/data.rst
@@ -86,6 +86,12 @@ In settings.py::
 
     DDF_IGNORE_FIELDS = ['field_x', 'field_y'] # default = []
 
+Ignored field names can use wildcard matching with '*' and '?' characters which substitute multiple or one character respectively. Wildcards are useful for fields that should not be populated and which match a pattern, like ``*_ptr`` fields for [django-polymorphic](https://github.com/django-polymorphic/django-polymorphic).
+
+In settings.py::
+
+    DDF_IGNORE_FIELDS = ['*_ptr'] # Ignore django-polymorphic pointer fields
+
 It is not possible to override the global configuration, just extend the list. So use global option with caution::
 
     instance = G(MyModel, ignore_fields=['another_field_name'])


### PR DESCRIPTION
Permit ignored field values specified directly or via
`DDF_IGNORED_FIELDS` to match model field names using standard wildcard
rules where '*' can substitute zero or more characters and '?' can
substitute a single character.

This is mainly useful for situations where you need to ignore model
fields in bulk where those fields match a specific pattern, such as
django-polymorphic's `*_ptr` pointer fields.

See https://github.com/paulocheque/django-dynamic-fixture/issues/67