### PR TITLE
Make `get_related_model` Django 2.0 -compatible

### DIFF
--- a/django_dynamic_fixture/django_helper.py
+++ b/django_dynamic_fixture/django_helper.py
@@ -165,7 +165,7 @@ def get_unique_field_name(field):
 
 
 def get_related_model(field):
-    return field.rel.to
+    return field.remote_field.model if hasattr(field, 'remote_field') else field.rel.to
 
 
 def field_is_a_parent_link(field):


### PR DESCRIPTION
I get a deprecation warning on Django 1.10:

`/.../lib/python2.7/site-packages/django_dynamic_fixture/django_helper.py:168: RemovedInDjango20Warning: Usage of ForeignObjectRel.to attribute has been deprecated. Use the model attribute instead.`

This commit removes the warning in a backwards compatible way.