### PR TITLE
Fixed ImportError on Django 2.0

### DIFF
--- a/django_dynamic_fixture/global_settings.py
+++ b/django_dynamic_fixture/global_settings.py
@@ -7,7 +7,12 @@ This is the facade of all features of DDF.
 import sys
 
 from django.conf import settings
-from django.core.urlresolvers import get_mod_func
+try:
+    # Django 2.0
+    from django.urls import get_mod_func
+except ImportError:
+    # Django <= 1.11
+    from django.core.urlresolvers import get_mod_func
 try:
     from importlib import import_module
 except ImportError:


### PR DESCRIPTION
This fixes an ImportError error when importing django_dynamic_fixture in a Django 2.0 project. 