### PR TITLE
Django 3.0 field choices may be None.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,65 @@
-dist: trusty
+dist: xenial
 sudo: true
 
 language: python
 python:
   - 2.7
+  - 3.4
+  - 3.5
   - 3.6
+  - 3.7
+  - 3.8
 
 install:
   - pip install tox
   - pip install coveralls
+  - sudo apt-get install gdal-bin libgdal-dev
   #- pip install python-coveralls
 
 env:
-  - DJANGO=django18
-  - DJANGO=django19
-  - DJANGO=django110
   - DJANGO=django111
-  # - DJANGO=django20
+  - DJANGO=django11117
+  - DJANGO=django20
+  - DJANGO=django21
+  - DJANGO=django22
+  - DJANGO=django228
+  - DJANGO=django30
 
 # Workaround for Travis issues with unknown python interpreters
 matrix:
   exclude:
     - python: 2.7
       env: DJANGO=django20
+    - python: 2.7
+      env: DJANGO=django21
+    - python: 2.7
+      env: DJANGO=django22
+    - python: 2.7
+      env: DJANGO=django228
+    - python: 2.7
+      env: DJANGO=django30
+    - python: 3.4
+      env: DJANGO=django21
+    - python: 3.4
+      env: DJANGO=django22
+    - python: 3.4
+      env: DJANGO=django228
+    - python: 3.4
+      env: DJANGO=django30
+    - python: 3.5
+      env: DJANGO=django30
+    - python: 3.7
+      env: DJANGO=django111
+    - python: 3.8
+      env: DJANGO=django111
+    - python: 3.8
+      env: DJANGO=django11117
+    - python: 3.8
+      env: DJANGO=django20
+    - python: 3.8
+      env: DJANGO=django21
+    - python: 3.8
+      env: DJANGO=django22
 
 script:
   - tox -e $DJANGO-py${TRAVIS_PYTHON_VERSION//[.]/}

--- a/django_dynamic_fixture/django_helper.py
+++ b/django_dynamic_fixture/django_helper.py
@@ -180,6 +180,9 @@ def field_has_choices(field):
     don't want to convert it to a list. We only care if the list is empty
     or not, so just try to access the first element and return True if that
     doesn't throw an exception."""
+    # Django 3.x no longer helps make choices non-None by default.
+    if field.choices is None:
+        return False
     for i in field.choices:
         return True
     return False

--- a/django_dynamic_fixture/models_test.py
+++ b/django_dynamic_fixture/models_test.py
@@ -99,7 +99,7 @@ class ModelWithDefaultValues(models.Model):
     string_with_choices = models.CharField(max_length=5, null=True, choices=(('a', 'A'), ('b', 'B')))
     string_with_choices_and_default = models.CharField(max_length=5, null=True, default='b', choices=(('a', 'A'), ('b', 'B')))
     string_with_optgroup_choices = models.CharField(max_length=5, null=True, choices=(('group1', (('a', 'A'), ('b', 'B'))), ('group2', (('c', 'C'), ('d', 'D')))))
-    foreign_key_with_default = models.ForeignKey(EmptyModel, null=True, default=None, on_delete=None)
+    foreign_key_with_default = models.ForeignKey(EmptyModel, null=True, default=None, on_delete=models.CASCADE)
 
     class Meta:
         verbose_name = 'Default values'
@@ -128,8 +128,8 @@ class ModelForIgnoreList(models.Model):
     required_with_default = models.IntegerField(null=False, default=1)
     not_required = models.IntegerField(null=True)
     not_required_with_default = models.IntegerField(null=True, default=1)
-    self_reference = models.ForeignKey('ModelForIgnoreList', null=True, on_delete=None)
-    different_reference = models.ForeignKey(ModelForIgnoreList2, null=True, on_delete=None)
+    self_reference = models.ForeignKey('ModelForIgnoreList', null=True, on_delete=models.CASCADE)
+    different_reference = models.ForeignKey(ModelForIgnoreList2, null=True, on_delete=models.CASCADE)
 
     class Meta:
         verbose_name = 'Ignore list'
@@ -137,7 +137,7 @@ class ModelForIgnoreList(models.Model):
 
 
 class ModelRelated(models.Model):
-    selfforeignkey = models.ForeignKey('self', null=True, on_delete=None)
+    selfforeignkey = models.ForeignKey('self', null=True, on_delete=models.CASCADE)
     integer = models.IntegerField(null=True)
     integer_b = models.IntegerField(null=True)
 
@@ -147,8 +147,8 @@ class ModelRelated(models.Model):
 
 
 class ModelRelatedThrough(models.Model):
-    related = models.ForeignKey('ModelRelated', on_delete=None)
-    relationship = models.ForeignKey('ModelWithRelationships', on_delete=None)
+    related = models.ForeignKey('ModelRelated', on_delete=models.CASCADE)
+    relationship = models.ForeignKey('ModelWithRelationships', on_delete=models.CASCADE)
 
     class Meta:
         app_label = 'django_dynamic_fixture'
@@ -167,14 +167,14 @@ def default_fk_id():
 
 class ModelWithRelationships(models.Model):
     # relationship
-    selfforeignkey = models.ForeignKey('self', null=True, on_delete=None)
-    foreignkey = models.ForeignKey('ModelRelated', related_name='fk', null=True, on_delete=None)
-    onetoone = models.OneToOneField('ModelRelated', related_name='o2o', null=True, on_delete=None)
+    selfforeignkey = models.ForeignKey('self', null=True, on_delete=models.CASCADE)
+    foreignkey = models.ForeignKey('ModelRelated', related_name='fk', null=True, on_delete=models.CASCADE)
+    onetoone = models.OneToOneField('ModelRelated', related_name='o2o', null=True, on_delete=models.CASCADE)
     manytomany = models.ManyToManyField('ModelRelated', related_name='m2m')
     manytomany_through = models.ManyToManyField('ModelRelated', related_name='m2m_through', through=ModelRelatedThrough)
 
-    foreignkey_with_default = models.ForeignKey('ModelRelated', related_name='fk2', null=True, default=default_fk_value, on_delete=None)
-    foreignkey_with_id_default = models.ForeignKey('ModelRelated', related_name='fk3', null=True, default=default_fk_id, on_delete=None)
+    foreignkey_with_default = models.ForeignKey('ModelRelated', related_name='fk2', null=True, default=default_fk_value, on_delete=models.CASCADE)
+    foreignkey_with_id_default = models.ForeignKey('ModelRelated', related_name='fk3', null=True, default=default_fk_id, on_delete=models.CASCADE)
 
     integer = models.IntegerField(null=True)
     integer_b = models.IntegerField(null=True)
@@ -187,7 +187,7 @@ class ModelWithRelationships(models.Model):
 
 
 class ModelWithCyclicDependency(models.Model):
-    d = models.ForeignKey('ModelWithCyclicDependency2', null=True, on_delete=None)
+    d = models.ForeignKey('ModelWithCyclicDependency2', null=True, on_delete=models.CASCADE)
 
     class Meta:
         verbose_name = 'Cyclic dependency'
@@ -195,7 +195,7 @@ class ModelWithCyclicDependency(models.Model):
 
 
 class ModelWithCyclicDependency2(models.Model):
-    c = models.ForeignKey(ModelWithCyclicDependency, null=True, on_delete=None)
+    c = models.ForeignKey(ModelWithCyclicDependency, null=True, on_delete=models.CASCADE)
 
     class Meta:
         verbose_name = 'Cyclic dependency 2'
@@ -223,7 +223,7 @@ class ModelChild(ModelParent):
 
 
 class ModelChildWithCustomParentLink(ModelParent):
-    my_custom_ref = models.OneToOneField(ModelParent, parent_link=True, related_name='my_custom_ref_x', on_delete=None)
+    my_custom_ref = models.OneToOneField(ModelParent, parent_link=True, related_name='my_custom_ref_x', on_delete=models.CASCADE)
 
     class Meta:
         verbose_name = 'Custom child'
@@ -231,7 +231,7 @@ class ModelChildWithCustomParentLink(ModelParent):
 
 
 class ModelWithRefToParent(models.Model):
-    parent = models.ForeignKey(ModelParent, on_delete=None)
+    parent = models.ForeignKey(ModelParent, on_delete=models.CASCADE)
 
     class Meta:
         verbose_name = 'Child with parent'
@@ -320,7 +320,7 @@ class ModelForCopy(models.Model):
     int_b = models.IntegerField(null=None)
     int_c = models.IntegerField()
     int_d = models.IntegerField()
-    e = models.ForeignKey(ModelForCopy2, on_delete=None)
+    e = models.ForeignKey(ModelForCopy2, on_delete=models.CASCADE)
 
     class Meta:
         verbose_name = 'Copy'
@@ -339,8 +339,8 @@ class ModelForLibrary2(models.Model):
 class ModelForLibrary(models.Model):
     integer = models.IntegerField(null=True)
     integer_unique = models.IntegerField(null=True, unique=True)
-    selfforeignkey = models.ForeignKey('self', null=True, on_delete=None)
-    foreignkey = models.ForeignKey('ModelForLibrary2', related_name='fk', null=True, on_delete=None)
+    selfforeignkey = models.ForeignKey('self', null=True, on_delete=models.CASCADE)
+    foreignkey = models.ForeignKey('ModelForLibrary2', related_name='fk', null=True, on_delete=models.CASCADE)
 
     class Meta:
         verbose_name = 'Library'

--- a/django_dynamic_fixture/tests/test_ddf.py
+++ b/django_dynamic_fixture/tests/test_ddf.py
@@ -835,20 +835,20 @@ class ExceptionsLayoutMessagesTest(DDFTestCase):
             model_msg = 'django_dynamic_fixture.models_test.ModelForIgnoreList'
             error_msg = 'django_dynamic_fixture_modelforignorelist.required may not be NULL'
             error_msg2 = 'NOT NULL constraint failed: django_dynamic_fixture_modelforignorelist.required'
-            template1 = "('%s', IntegrityError('%s',))" % (model_msg, error_msg)
-            template2 = "('%s', IntegrityError('%s',))" % (model_msg, error_msg2) # py34
-            template3 = "('%s', IntegrityError(u'%s',))" % (model_msg, error_msg) # pypy
-            template4 = "('%s', IntegrityError(u'%s',))" % (model_msg, error_msg2) # pypy
-            self.assertEquals(str(e) in [template1, template2, template3, template4], True, msg=str(e))
-
+            template1 = "('%s', IntegrityError('%s'" % (model_msg, error_msg)
+            template2 = "('%s', IntegrityError('%s'" % (model_msg, error_msg2) # py34
+            template3 = "('%s', IntegrityError(u'%s'" % (model_msg, error_msg) # pypy
+            template4 = "('%s', IntegrityError(u'%s'" % (model_msg, error_msg2) # pypy
+            self.assertTrue(any(item in str(e) for item in [template1, template2, template3, template4]), msg=str(e))
 
     def test_InvalidConfigurationError(self):
         try:
             self.ddf.new(ModelWithNumbers, integer=lambda x: ''.invalidmethod())
             self.fail()
         except InvalidConfigurationError as e:
-            self.assertTrue('django_dynamic_fixture.models_test.ModelWithNumbers.integer' in str(e))
-            self.assertTrue("AttributeError("'str' object has no attribute 'invalidmethod'"))" in str(e))
+            self.assertTrue('django_dynamic_fixture.models_test.ModelWithNumbers.integer' in str(e), str(e))
+            invalid_method_str = "AttributeError(\"'str' object has no attribute 'invalidmethod'\""
+            self.assertTrue(invalid_method_str in str(e), str(e))
 
     def test_InvalidManyToManyConfigurationError(self):
         try:

--- a/django_dynamic_fixture/tests/test_django_helper.py
+++ b/django_dynamic_fixture/tests/test_django_helper.py
@@ -105,7 +105,7 @@ class DjangoHelperModelsTest(TestCase):
     def test_model_has_the_field(self):
         class ModelWithWithoutFields_test_model_has_the_field(models.Model):
             integer = models.IntegerField()
-            selfforeignkey = models.ForeignKey('self', null=True, on_delete=None)
+            selfforeignkey = models.ForeignKey('self', null=True, on_delete=models.CASCADE)
             manytomany = models.ManyToManyField('self', related_name='m2m')
         self.assertEquals(True, model_has_the_field(ModelWithWithoutFields_test_model_has_the_field, 'integer'))
         self.assertEquals(True, model_has_the_field(ModelWithWithoutFields_test_model_has_the_field, 'selfforeignkey'))
@@ -123,16 +123,16 @@ class DjangoHelperFieldsTest(TestCase):
     def test_get_related_model(self):
         class ModelRelated_test_get_related_model(models.Model): pass
         class Model4GetRelatedModel_test_get_related_model(models.Model):
-            fk = models.ForeignKey(ModelRelated_test_get_related_model, on_delete=None)
+            fk = models.ForeignKey(ModelRelated_test_get_related_model, on_delete=models.CASCADE)
         self.assertEquals(ModelRelated_test_get_related_model,
                           get_related_model(get_field_by_name_or_raise(Model4GetRelatedModel_test_get_related_model, 'fk')))
 
     def test_field_is_a_parent_link(self):
         class ModelParent_test_get_related_model(models.Model): pass
         class Model4FieldIsParentLink_test_get_related_model(ModelParent):
-            o2o_with_parent_link = models.OneToOneField(ModelParent_test_get_related_model, parent_link=True, related_name='my_custom_ref_x', on_delete=None)
+            o2o_with_parent_link = models.OneToOneField(ModelParent_test_get_related_model, parent_link=True, related_name='my_custom_ref_x', on_delete=models.CASCADE)
         class Model4FieldIsParentLink2(ModelParent):
-            o2o_without_parent_link = models.OneToOneField(ModelParent_test_get_related_model, parent_link=False, related_name='my_custom_ref_y', on_delete=None)
+            o2o_without_parent_link = models.OneToOneField(ModelParent_test_get_related_model, parent_link=False, related_name='my_custom_ref_y', on_delete=models.CASCADE)
         # FIXME
         #self.assertEquals(True, field_is_a_parent_link(get_field_by_name_or_raise(Model4FieldIsParentLink, 'o2o_with_parent_link')))
         self.assertEquals(False, field_is_a_parent_link(get_field_by_name_or_raise(Model4FieldIsParentLink2, 'o2o_without_parent_link')))
@@ -166,8 +166,8 @@ class DjangoHelperFieldsTest(TestCase):
 
     def test_is_relationship_field(self):
         class ModelForRelationshipField_test_is_relationship_field(models.Model):
-            fk = models.ForeignKey('self', on_delete=None)
-            one2one = models.OneToOneField('self', on_delete=None)
+            fk = models.ForeignKey('self', on_delete=models.CASCADE)
+            one2one = models.OneToOneField('self', on_delete=models.CASCADE)
         self.assertEquals(True, is_relationship_field(get_field_by_name_or_raise(ModelForRelationshipField_test_is_relationship_field, 'fk')))
         self.assertEquals(True, is_relationship_field(get_field_by_name_or_raise(ModelForRelationshipField_test_is_relationship_field, 'one2one')))
         self.assertEquals(False, is_relationship_field(get_field_by_name_or_raise(ModelForRelationshipField_test_is_relationship_field, 'id')))

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
 envlist =
-    django{17}-py{27,33},
-    django{18}-py{27,34},
-    django{19}-py{27,35},
-    django{110}-py{27,36},
-    django{111}-py{27,36},
-    django{20}-py{35,36},
+    django{111}-py{27,34,35,36},
+    django{11117}-py{27,34,35,36,37},
+    django{20}-py{34,35,36,37},
+    django{21}-py{35,36,37},
+    django{22}-py{35,36,37},
+    django{228}-py{35,36,37,38},
+    django{30}-py{36,37,38},
 
 [testenv]
 setenv =
@@ -17,25 +18,22 @@ setenv =
     NOSE_OPENSTACK_SHOW_ELAPSED=1
 
 basepython=
-    py26: python2.6
     py27: python2.7
-    py32: python3.2
-    py33: python3.3
     py34: python3.4
     py35: python3.5
     py36: python3.6
+    py37: python3.7
+    py38: python3.8
     pypy: pypy
 
 deps =
     -r{toxinidir}/requirements.txt
-    django14: django>=1.4,<1.5
-    django15: django>=1.5,<1.6
-    django16: django>=1.6,<1.7
-    django17: django>=1.7,<1.8
-    django18: django>=1.8,<1.9
-    django19: django>=1.9,<1.10
-    django110: django>=1.10,<1.11
     django111: django>=1.11,<2.0
+    django11117: django>=1.11.17,<2.0
     django20: django>=2.0,<2.1
+    django21: django>=2.1,<2.2
+    django22: django>=2.2,<3.0
+    django228: django>=2.2.8,<3.0
+    django30: django>=3.0,<3.1
 
 commands = {toxinidir}/runtests.py


### PR DESCRIPTION
Bugfix around a behavior/code flow change from Django 3.0.

Turns out due to some of the changes around the 2.x and 3.x series if we want to keep general support (and look to the future), we needed more changes around the interpreters, django versions, and the test setup/assertions. Nothing tremendous -- so long as the tests end up passing, I think beyond it being a version update we should be fine with this.

Currently failing around GDAL installation issues.