### PR TITLE
Bugfixes: default value and number of laps equals to 0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,33 +27,40 @@ matrix:
     env:
       - DJANGO=1.11
       - DATABASE=sqlite
+      - JSONFIELD=2.1.1
   - python: 2.7
     env:
       - DJANGO=1.11
       - DATABASE=postgres
+      - JSONFIELD=2.1.1
   # https://docs.djangoproject.com/en/2.2/ref/contrib/gis/install/
   - python: 3.6
     env:
       - DJANGO=2.2
       - DATABASE=sqlite
+      - JSONFIELD=3.1.0
   - python: 3.6
     env:
       - DJANGO=2.2
       - DATABASE=postgres
+      - JSONFIELD=3.1.0
   # https://docs.djangoproject.com/en/3.0/ref/contrib/gis/install/
   # https://docs.djangoproject.com/en/3.0/releases/3.0/#id2
   - python: 3.7
     env:
       - DJANGO=3.0
       - DATABASE=sqlite
+      - JSONFIELD=3.1.0
   - python: 3.8
     env:
       - DJANGO=3.0
       - DATABASE=sqlite
+      - JSONFIELD=3.1.0
   - python: 3.8
     env:
       - DJANGO=3.0
       - DATABASE=postgres
+      - JSONFIELD=3.1.0
 
 before_script:
   - export PYTHONPATH=$PYTHONPATH:$(pwd)
@@ -76,6 +83,7 @@ install:
   - pip install -r requirements.txt
   - pip install psycopg2 pytest pytest-django coveralls
   - pip install Django~=${DJANGO}.0
+  - pip install jsonfield~=${JSONFIELD}
 
 script:
   - pytest --create-db --reuse-db --no-migrations --ds=settings_${DATABASE}

--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,13 @@ compile:
 
 test:
 	# Run specific test:
-	# TESTS=pytest django_dynamic_fixture.tests.FILE::CLASS::METHOD make test
+	# TESTS=django_dynamic_fixture.tests.FILE::CLASS::METHOD make test
 	clear ; env/bin/pytest --create-db --reuse-db --no-migrations ${TESTS}
 	# clear ; time env/bin/tox --parallel all -e django111-py27
 	# clear ; time env/bin/tox --parallel all -e django20-py37
+
+testfailed:
+	clear ; env/bin/pytest --create-db --reuse-db --no-migrations ${TESTS} --last-failed
 
 config_postgres:
 	psql -U postgres -c "create extension postgis"

--- a/django_dynamic_fixture/__init__.py
+++ b/django_dynamic_fixture/__init__.py
@@ -14,7 +14,7 @@ from django_dynamic_fixture.ddf import DynamicFixture, Copier, DDFLibrary, \
 from django_dynamic_fixture.django_helper import print_field_values, django_greater_than
 from django_dynamic_fixture.fixture_algorithms.sequential_fixture import SequentialDataFixture, \
     StaticSequentialDataFixture
-from django_dynamic_fixture.global_settings import DDF_DEFAULT_DATA_FIXTURE, DDF_FILL_NULLABLE_FIELDS, DDF_NUMBER_OF_LAPS, \
+from django_dynamic_fixture.global_settings import DDF_DEFAULT_DATA_FIXTURE, DDF_FILL_NULLABLE_FIELDS, DDF_FK_MIN_DEPTH, \
                                                     DDF_IGNORE_FIELDS, DDF_VALIDATE_MODELS, \
                                                     DDF_DEBUG_MODE, DDF_FIELD_FIXTURES
 from django_dynamic_fixture.script_ddf_checkings import ddf_check_models
@@ -75,7 +75,7 @@ def fixture(**kwargs):
     f = DynamicFixture(data_fixture=kwargs.pop('data_fixture', DDF_DEFAULT_DATA_FIXTURE),
                        fill_nullable_fields=kwargs.pop('fill_nullable_fields', DDF_FILL_NULLABLE_FIELDS),
                        ignore_fields=kwargs.pop('ignore_fields', []),
-                       number_of_laps=kwargs.pop('number_of_laps', DDF_NUMBER_OF_LAPS),
+                       fk_min_depth=kwargs.pop('fk_min_depth', DDF_FK_MIN_DEPTH),
                        validate_models=kwargs.pop('validate_models', DDF_VALIDATE_MODELS),
                        print_errors=kwargs.pop('print_errors', True),
                        debug_mode=kwargs.pop('debug_mode', DDF_DEBUG_MODE),
@@ -98,7 +98,7 @@ def _new(model, n=1, ddf_lesson=None, persist_dependencies=False, **kwargs):
     @data_fixture: override DDF_DEFAULT_DATA_FIXTURE configuration. Default is SequentialDataFixture().
     @fill_nullable_fields: override DDF_FILL_NULLABLE_FIELDS global configuration. Default is True.
     @ignore_fields: List of fields that will be ignored by DDF. It will be concatenated with the global list DDF_IGNORE_FIELDS. Default is [].
-    @number_of_laps: override DDF_NUMBER_OF_LAPS global configuration. Default 1.
+    @fk_min_depth: override DDF_FK_MIN_DEPTH global configuration. Default 0.
     @validate_models: override DDF_VALIDATE_MODELS global configuration. Default is False.
     @print_errors: print on console all instance values if DDF can not generate a valid object with the given configuration.
 
@@ -128,7 +128,7 @@ def _get(model, n=1, ddf_lesson=None, **kwargs):
     @data_fixture: override DDF_DEFAULT_DATA_FIXTURE configuration. Default is SequentialDataFixture().
     @fill_nullable_fields: override DDF_FILL_NULLABLE_FIELDS global configuration. Default is True.
     @ignore_fields: List of fields that will be ignored by DDF. It will be concatenated with the global list DDF_IGNORE_FIELDS. Default is [].
-    @number_of_laps: override DDF_NUMBER_OF_LAPS global configuration. Default 1.
+    @fk_min_depth: override DDF_FK_MIN_DEPTH global configuration. Default 0.
     @validate_models: override DDF_VALIDATE_MODELS global configuration. Default is False.
     @print_errors: print on console all instance values if DDF can not generate a valid object with the given configuration.
 

--- a/django_dynamic_fixture/ddf.py
+++ b/django_dynamic_fixture/ddf.py
@@ -239,7 +239,7 @@ class DynamicFixture(object):
     _DDF_CONFIGS = ['fill_nullable_fields', 'ignore_fields', 'data_fixture', 'number_of_laps',
                     'validate_models', 'print_errors']
 
-    def __init__(self, data_fixture, fill_nullable_fields=True, ignore_fields=[], number_of_laps=1,
+    def __init__(self, data_fixture, fill_nullable_fields=False, ignore_fields=[], number_of_laps=0,
                  validate_models=False, print_errors=True, model_path=[], debug_mode=False, **kwargs):
         '''
         :data_fixture: algorithm to fill field data.
@@ -337,17 +337,20 @@ class DynamicFixture(object):
             return None
         next_model = get_related_model(field)
         occurrences = self.model_path.count(next_model)
-        if occurrences >= self.number_of_laps:
+
+        # Skip occurrences=0 for the first lap/cycle.
+        # This should work for FK and Self-FKs
+        if occurrences and occurrences >= self.number_of_laps:
             data = None
         else:
             next_model_path = self.model_path[:]
             next_model_path.append(model_class)
+            # 1. Propagate ignored_fields only for self references
             if model_class == next_model: # self reference
-                # propagate ignored_fields only for self references
                 ignore_fields = self.ignore_fields
             else:
                 ignore_fields = []
-            # need a new DynamicFixture to control the cycles and ignored fields.
+            # 2. It needs a new DynamicFixture to control the cycles and ignored fields.
             fixture = DynamicFixture(data_fixture=self.data_fixture,
                                      fill_nullable_fields=self.fill_nullable_fields,
                                      ignore_fields=ignore_fields,
@@ -355,6 +358,7 @@ class DynamicFixture(object):
                                      validate_models=self.validate_models,
                                      print_errors=self.print_errors,
                                      model_path=next_model_path)
+            # 3. Persist it
             if persist_dependencies:
                 data = fixture.get(next_model)
             else:
@@ -362,20 +366,50 @@ class DynamicFixture(object):
         return data
 
     def _process_field_with_default_fixture(self, field, model_class, persist_dependencies):
-        "The field has no custom value, so the default behavior of the tool is applied."
-        if field.null and not self.fill_nullable_fields:
-            return None
-        if field_has_default_value(field):
-            if callable(field.default):
-                data = field.default() # datetime default can receive a function: datetime.now
+        '''
+        The field has no custom value (F, C, static, Lessons...), so the default behavior of the tool is applied.
+        - DDF behavior priority for common fields:
+        1. Use `null` if possible (considering the `fill_nullable_fields` settings)
+        2. Use the `default` value
+        3. Use the first option of `choices`
+        - DDF behavior priority for relationship fields:
+        1. Use the `default` value
+        2. Use `null` if possible (considering the `fill_nullable_fields` settings)
+        3. Create a new FK model
+        - DDF behavior priority for self relationship fields:
+        1. Use the `default` value
+        2. Use the `number_of_laps` instead of fill_nullable_fields
+        3. Use `null`
+        '''
+        next_model = get_related_model(field) if is_relationship_field(field) else None
+
+        if not is_relationship_field(field):
+            if field.null and not self.fill_nullable_fields:
+                data = None
+            elif field_has_default_value(field):
+                # datetime default can receive a function: datetime.now
+                data = field.default() if callable(field.default) else field.default
+            elif field_has_choices(field):
+                data = field.flatchoices[0][0] # key of the first choice
             else:
-                data = field.default
-        elif field_has_choices(field):
-            data = field.flatchoices[0][0] # key of the first choice
-        elif is_relationship_field(field):
-            data = self._process_foreign_key(model_class, field, persist_dependencies)
+                data = self.data_fixture.generate_data(field)
         else:
-            data = self.data_fixture.generate_data(field)
+            if field_has_default_value(field):
+                # datetime default can receive a function: datetime.now
+                data = field.default() if callable(field.default) else field.default
+            else:
+                # `number_of_laps` overrides the `fill_nullable_fields` for self FKs
+                next_model = get_related_model(field)
+                if model_class == next_model: # self reference
+                    if self.number_of_laps > 0:
+                        data = self._process_foreign_key(model_class, field, persist_dependencies)
+                    else:
+                        data = None
+                else:
+                    if field.null and not self.fill_nullable_fields:
+                        data = None
+                    else:
+                        data = self._process_foreign_key(model_class, field, persist_dependencies)
         return data
 
     def set_data_for_a_field(self, model_class, __instance, __field, persist_dependencies=True, **kwargs):

--- a/django_dynamic_fixture/ddf.py
+++ b/django_dynamic_fixture/ddf.py
@@ -87,27 +87,27 @@ def _validate_function(model_class, callback_function):
 
 
 def set_pre_save_receiver(model_class, callback_function):
-    """
+    '''
     :model_class: a model_class can have only one receiver. Do not complicate yourself.
     :callback_function must be a function that receive the instance as unique parameter.
-    """
+    '''
     _validate_model(model_class)
     _validate_function(model_class, callback_function)
     _PRE_SAVE[model_class] = callback_function
 
 
 def set_post_save_receiver(model_class, callback_function):
-    """
+    '''
     :model_class: a model_class can have only one receiver. Do not complicate yourself.
     :callback_function must be a function that receive the instance as unique parameter.
-    """
+    '''
     _validate_model(model_class)
     _validate_function(model_class, callback_function)
     _POST_SAVE[model_class] = callback_function
 
 
 class DataFixture(object):
-    """
+    '''
     Responsibility: return a valid data for a Django Field, according to its type, model class, constraints etc.
 
     You must create a separated method to generate data for an specific field. For a field called 'MyField',
@@ -117,7 +117,7 @@ class DataFixture(object):
 
     :field: Field object.
     :key: string that represents a unique name for a Field, considering app, model and field names.
-    """
+    '''
     def __init__(self):
         self.plugins = {}
 
@@ -139,7 +139,7 @@ class DataFixture(object):
                 return None
 
     def generate_data(self, field):
-        "Get a unique and valid data for the field."
+        '''Get a unique and valid data for the field.'''
         field_fullname = field.__module__ + "." + field.__class__.__name__
         fixture = self.plugins.get(field_fullname, {})
         if type(fixture) == dict:
@@ -160,11 +160,11 @@ class DataFixture(object):
 
 
 class Copier(object):
-    """
+    '''
     Wrapper of an expression in the format 'field' or 'field.field' or 'field.field.field' etc
     This expression will be interpreted to copy the value of the specified field to the current field.
     Example of usage: G(MyModel, x=C('y.z')) => the value 'z' of field 'y' will be copied to field 'x'.
-    """
+    '''
     def __init__(self, expression):
         self.expression = expression
 
@@ -222,26 +222,26 @@ class DDFLibrary(object):
         return config.get(name, {}).copy() # default configuration never raises an error
 
     def clear(self):
-        "Remove all lessons of the library. Util for the DDF tests."
+        '''Remove all lessons of the library. Util for the DDF tests.'''
         self.configs = {}
 
     def clear_configuration(self, model_class):
-        "Remove from the library an specific configuration of a model."
+        '''Remove from the library an specific configuration of a model.'''
         if model_class in self.configs.keys():
             del self.configs[model_class]
 
 
 class DynamicFixture(object):
-    """
+    '''
     Responsibility: create a valid model instance according to the given configuration.
-    """
+    '''
 
     _DDF_CONFIGS = ['fill_nullable_fields', 'ignore_fields', 'data_fixture', 'number_of_laps',
                     'validate_models', 'print_errors']
 
     def __init__(self, data_fixture, fill_nullable_fields=True, ignore_fields=[], number_of_laps=1,
                  validate_models=False, print_errors=True, model_path=[], debug_mode=False, **kwargs):
-        """
+        '''
         :data_fixture: algorithm to fill field data.
         :fill_nullable_fields: flag to decide if nullable fields must be filled with data.
         :ignore_fields: list of field names that must not be filled with data.
@@ -249,7 +249,7 @@ class DynamicFixture(object):
         :validate_models: flag to decide if the model_instance.full_clean() must be called before saving the object.
         :print_errors: flag to determine if the model data must be printed to console on errors. For some scripts is interesting to disable it.
         :model_path: internal variable used to control the cycles of dependencies.
-        """
+        '''
         from django_dynamic_fixture.global_settings import DDF_IGNORE_FIELDS
         from django_dynamic_fixture.fixture_algorithms import FixtureFactory
         # custom config of fixtures
@@ -279,7 +279,7 @@ class DynamicFixture(object):
         return self.kwargs == that.kwargs
 
     def _get_data_from_custom_dynamic_fixture(self, field, fixture, persist_dependencies):
-        "return data of a Dynamic Fixture: field=F(...)"
+        '''return data of a Dynamic Fixture: field=F(...)'''
         next_model = get_related_model(field)
         if persist_dependencies:
             data = fixture.get(next_model)
@@ -288,7 +288,7 @@ class DynamicFixture(object):
         return data
 
     def _get_data_from_custom_copier(self, instance, field, fixture):
-        "return data of a Copier: field=C(...)"
+        '''return data of a Copier: field=C(...)'''
         field_name = fixture.immediate_field_name(instance)
         if field_name in self.fields_processed:
             data = fixture.eval_expression(instance)
@@ -298,17 +298,17 @@ class DynamicFixture(object):
         return data
 
     def _get_data_from_data_fixture(self, field, fixture):
-        "return data of a Data Fixture: field=DataFixture()"
+        '''return data of a Data Fixture: field=DataFixture()'''
         next_model = get_related_model(field)
         return fixture.generate_data(next_model)
 
     def _get_data_from_a_custom_function(self, field, fixture):
-        "return data of a custom function: field=lambda field: field.name"
+        '''Returns data of a custom function: field=lambda field: field.name'''
         data = fixture(field)
         return data
 
     def _get_data_from_static_data(self, field, fixture):
-        "return date from a static value: field=3"
+        '''return date from a static value: field=3'''
         if hasattr(field, 'auto_now_add') and field.auto_now_add:
             self.fields_to_disable_auto_now_add.append(field)
         if hasattr(field, 'auto_now') and field.auto_now:
@@ -316,7 +316,7 @@ class DynamicFixture(object):
         return fixture
 
     def _process_field_with_customized_fixture(self, instance, field, fixture, persist_dependencies):
-        "Set a custom value to a field."
+        '''Set a custom value to a field.'''
         if isinstance(fixture, DynamicFixture): # DynamicFixture (F)
             data = self._get_data_from_custom_dynamic_fixture(field, fixture, persist_dependencies)
         elif isinstance(fixture, Copier): # Copier (C)
@@ -330,7 +330,9 @@ class DynamicFixture(object):
         return data
 
     def _process_foreign_key(self, model_class, field, persist_dependencies):
-        "Returns auto-generated value for a field ForeignKey or OneToOneField."
+        '''
+        Returns auto-generated value for a field ForeignKey or OneToOneField.
+        '''
         if field_is_a_parent_link(field):
             return None
         next_model = get_related_model(field)
@@ -420,7 +422,7 @@ class DynamicFixture(object):
         self.fields_processed.append(__field.name)
 
     def _validate_kwargs(self, model_class, kwargs):
-        "validate all kwargs match Model.fields."
+        '''validate all kwargs match Model.fields.'''
         for field_name in kwargs.keys():
             if field_name in self._DDF_CONFIGS:
                 continue
@@ -428,11 +430,11 @@ class DynamicFixture(object):
                 raise InvalidConfigurationError('Field "%s" does not exist.' % field_name)
 
     def _configure_params(self, model_class, ddf_lesson, **kwargs):
-        """
+        '''
         1) validate kwargs
         2) load default fixture from DDF library. Store default fixture in DDF library.
         3) Load fixtures defined in F attributes.
-        """
+        '''
         self._validate_kwargs(model_class, kwargs)
 
         # load ddf_setup.py of the model application
@@ -463,7 +465,7 @@ class DynamicFixture(object):
         return configuration
 
     def new(self, model_class, ddf_lesson=None, persist_dependencies=True, **kwargs):
-        """
+        '''
         Create an instance filled with data without persist it.
         1) validate all kwargs match Model.fields.
         2) validate model is a model.Model class.
@@ -471,7 +473,7 @@ class DynamicFixture(object):
 
         :ddf_lesson: the lesson that will be used to create the model instance, if exists.
         :persist_dependencies: tell if internal dependencies will be saved in the database or not.
-        """
+        '''
         if self.debug_mode:
             LOGGER.debug('>>> [%s] Generating instance.' % get_unique_model_name(model_class))
         configuration = self._configure_params(model_class, ddf_lesson, **kwargs)
@@ -505,11 +507,11 @@ class DynamicFixture(object):
         return instance
 
     def _is_ignored_field(self, field_name):
-        """
+        '''
         Return `True` if the given field name should be ignored according to
         this class's `self.ignored_fields`. Both literal field names and
         names with wildcard '*' and '?' characters are supported.
-        """
+        '''
         # Do fast check for literal field name first
         if field_name in self.ignore_fields:
             return True
@@ -526,13 +528,13 @@ class DynamicFixture(object):
         return False
 
     def _process_many_to_many_field(self, field, manytomany_field, fixture, instance):
-        """
+        '''
         Set ManyToManyField fields with or without 'trough' option.
 
         :field: model field.
         :manytomany_field: ManyRelatedManager of the field.
         :fixture: value passed by user.
-        """
+        '''
         next_model = get_related_model(field)
         if isinstance(fixture, int):
             amount = fixture
@@ -577,11 +579,11 @@ class DynamicFixture(object):
             enable_auto_now_add(field)
 
     def get(self, model_class, ddf_lesson=None, **kwargs):
-        """
+        '''
         Create an instance with data and persist it.
 
         :ddf_lesson: a custom lesson that will be used to create the model object.
-        """
+        '''
         instance = self.new(model_class, ddf_lesson=ddf_lesson, **kwargs)
         if is_model_abstract(model_class):
             raise InvalidModelError(get_unique_model_name(model_class))
@@ -618,9 +620,9 @@ class DynamicFixture(object):
         return instance
 
     def teach(self, model_class, ddf_lesson=None, **kwargs):
-        """
+        '''
         @raise an CantOverrideLesson error if the same model/lesson were called twice.
-        """
+        '''
         library = DDFLibrary.get_instance()
         for field_name in kwargs.keys():
             if field_name in self._DDF_CONFIGS:

--- a/django_dynamic_fixture/ddf.py
+++ b/django_dynamic_fixture/ddf.py
@@ -376,11 +376,11 @@ class DynamicFixture(object):
                 else:
                     data = None
         else:
-            if field.null and not self.fill_nullable_fields:
-                data = None
-            elif field_has_default_value(field):
+            if field_has_default_value(field):
                 # datetime default can receive a function: datetime.now
                 data = field.default() if callable(field.default) else field.default
+            elif field.null and not self.fill_nullable_fields:
+                data = None
             elif field_has_choices(field):
                 data = field.flatchoices[0][0] # key of the first choice
             else:

--- a/django_dynamic_fixture/global_settings.py
+++ b/django_dynamic_fixture/global_settings.py
@@ -5,6 +5,7 @@ Module that contains wrappers and shortcuts.
 This is the facade of all features of DDF.
 """
 import sys
+import warnings
 
 from django.conf import settings
 try:
@@ -66,12 +67,17 @@ except Exception as e:
     six.reraise(DDFImproperlyConfigured, DDFImproperlyConfigured("DDF_IGNORE_FIELDS (%s) must be a list of strings" % settings.DDF_IGNORE_FIELDS), sys.exc_info()[2])
 
 
-# DDF_NUMBER_OF_LAPS default = 1
+# DDF_FK_MIN_DEPTH default = 0
 try:
-    DDF_NUMBER_OF_LAPS = int(settings.DDF_NUMBER_OF_LAPS) if hasattr(settings, 'DDF_NUMBER_OF_LAPS') else 0
+    DDF_FK_MIN_DEPTH = int(settings.DDF_FK_MIN_DEPTH) if hasattr(settings, 'DDF_FK_MIN_DEPTH') else 0
 except Exception as e:
-    six.reraise(DDFImproperlyConfigured, DDFImproperlyConfigured("DDF_NUMBER_OF_LAPS (%s) must be a integer number." % settings.DDF_NUMBER_OF_LAPS), sys.exc_info()[2])
+    six.reraise(DDFImproperlyConfigured, DDFImproperlyConfigured("DDF_FK_MIN_DEPTH (%s) must be a integer number." % settings.DDF_FK_MIN_DEPTH), sys.exc_info()[2])
 
+if hasattr(settings, 'DDF_NUMBER_OF_LAPS'):
+    warnings.warn(
+        "The old DDF_NUMBER_OF_LAPS settings was replaced by the new DDF_FK_MIN_DEPTH.",
+        DeprecationWarning
+    )
 
 # DDF_FIELD_FIXTURES default = {}
 try:

--- a/django_dynamic_fixture/models_test.py
+++ b/django_dynamic_fixture/models_test.py
@@ -16,13 +16,13 @@ class EmptyModel(models.Model):
 
 class ModelWithNumbers(models.Model):
     #id is a models.AutoField()
-    integer = models.IntegerField(null=True, unique=True)
-    smallinteger = models.SmallIntegerField(null=True, unique=True)
-    positiveinteger = models.PositiveIntegerField(null=True, unique=True)
-    positivesmallinteger = models.PositiveSmallIntegerField(null=True, unique=True)
-    biginteger = models.BigIntegerField(null=True, unique=True)
-    float = models.FloatField(null=True, unique=True)
-    decimal = models.DecimalField(max_digits=2, decimal_places=1, null=True, unique=False)
+    integer = models.IntegerField(unique=True)
+    smallinteger = models.SmallIntegerField(unique=True)
+    positiveinteger = models.PositiveIntegerField(unique=True)
+    positivesmallinteger = models.PositiveSmallIntegerField(unique=True)
+    biginteger = models.BigIntegerField(unique=True)
+    float = models.FloatField(unique=True)
+    decimal = models.DecimalField(max_digits=2, decimal_places=1, unique=False)
 
     class Meta:
         verbose_name = 'Numbers'
@@ -30,10 +30,10 @@ class ModelWithNumbers(models.Model):
 
 
 class ModelWithStrings(models.Model):
-    string = models.CharField(max_length=1, null=True, unique=True)
-    text = models.TextField(null=True, unique=True)
-    slug = models.SlugField(null=True, unique=True)
-    commaseparated = models.CommaSeparatedIntegerField(max_length=100, null=True, unique=True)
+    string = models.CharField(max_length=1, unique=True)
+    text = models.TextField(unique=True)
+    slug = models.SlugField(unique=True)
+    commaseparated = models.CommaSeparatedIntegerField(max_length=100, unique=True)
 
     class Meta:
         verbose_name = 'Strings'
@@ -52,9 +52,9 @@ class ModelWithBooleans(models.Model):
 
 
 class ModelWithDateTimes(models.Model):
-    date = models.DateField(null=True, unique=True)
-    datetime = models.DateTimeField(null=True, unique=True)
-    time = models.TimeField(null=True, unique=True)
+    date = models.DateField(unique=True)
+    datetime = models.DateTimeField(unique=True)
+    time = models.TimeField(unique=True)
 
     class Meta:
         verbose_name = 'DateTimes'
@@ -68,10 +68,10 @@ class ModelWithBinary(models.Model):
 
 
 class ModelWithFieldsWithCustomValidation(models.Model):
-    email = models.EmailField(null=True, unique=True)
-    url = models.URLField(null=True, unique=True)
-    ip = models.IPAddressField(null=True, unique=False)
-    ipv6 = models.GenericIPAddressField(null=True, unique=False)
+    email = models.EmailField(unique=True)
+    url = models.URLField(unique=True)
+    ip = models.IPAddressField(unique=False)
+    ipv6 = models.GenericIPAddressField(unique=False)
 
     class Meta:
         verbose_name = 'Custom validation'
@@ -94,10 +94,10 @@ class ModelWithFileFields(models.Model):
 
 
 class ModelWithDefaultValues(models.Model):
-    integer_with_default = models.IntegerField(null=True, default=3)
-    string_with_choices = models.CharField(max_length=5, null=True, choices=(('a', 'A'), ('b', 'B')))
-    string_with_choices_and_default = models.CharField(max_length=5, null=True, default='b', choices=(('a', 'A'), ('b', 'B')))
-    string_with_optgroup_choices = models.CharField(max_length=5, null=True, choices=(('group1', (('a', 'A'), ('b', 'B'))), ('group2', (('c', 'C'), ('d', 'D')))))
+    integer_with_default = models.IntegerField(default=3)
+    string_with_choices = models.CharField(max_length=5, choices=(('a', 'A'), ('b', 'B')))
+    string_with_choices_and_default = models.CharField(max_length=5, default='b', choices=(('a', 'A'), ('b', 'B')))
+    string_with_optgroup_choices = models.CharField(max_length=5, choices=(('group1', (('a', 'A'), ('b', 'B'))), ('group2', (('c', 'C'), ('d', 'D')))))
     foreign_key_with_default = models.ForeignKey(EmptyModel, null=True, default=None, on_delete=models.DO_NOTHING)
 
     class Meta:
@@ -127,9 +127,9 @@ class ModelForIgnoreList(models.Model):
     required = models.IntegerField(null=False)
     required_with_default = models.IntegerField(null=False, default=1)
     not_required = models.IntegerField(null=True)
-    not_required_with_default = models.IntegerField(null=True, default=1)
-    self_reference = models.ForeignKey('ModelForIgnoreList', null=True, on_delete=models.DO_NOTHING)
-    different_reference = models.ForeignKey(ModelForIgnoreList2, null=True, on_delete=models.DO_NOTHING)
+    not_required_with_default = models.IntegerField(default=1)
+    self_reference = models.ForeignKey('ModelForIgnoreList', on_delete=models.DO_NOTHING, null=True)
+    different_reference = models.ForeignKey(ModelForIgnoreList2, on_delete=models.DO_NOTHING)
 
     class Meta:
         verbose_name = 'Ignore list'
@@ -137,7 +137,7 @@ class ModelForIgnoreList(models.Model):
 
 
 class ModelRelated(models.Model):
-    selfforeignkey = models.ForeignKey('self', null=True, on_delete=models.DO_NOTHING)
+    selfforeignkey = models.ForeignKey('self', on_delete=models.DO_NOTHING, null=True, blank=True)
     integer = models.IntegerField(null=True)
     integer_b = models.IntegerField(null=True)
 
@@ -167,14 +167,14 @@ def default_fk_id():
 
 class ModelWithRelationships(models.Model):
     # relationship
-    selfforeignkey = models.ForeignKey('self', null=True, on_delete=models.DO_NOTHING)
-    foreignkey = models.ForeignKey('ModelRelated', related_name='fk', null=True, on_delete=models.DO_NOTHING)
-    onetoone = models.OneToOneField('ModelRelated', related_name='o2o', null=True, on_delete=models.DO_NOTHING)
+    selfforeignkey = models.ForeignKey('self', on_delete=models.DO_NOTHING, null=True, blank=True)
+    foreignkey = models.ForeignKey('ModelRelated', related_name='fk', on_delete=models.DO_NOTHING)
+    onetoone = models.OneToOneField('ModelRelated', related_name='o2o', on_delete=models.DO_NOTHING)
     manytomany = models.ManyToManyField('ModelRelated', related_name='m2m')
     manytomany_through = models.ManyToManyField('ModelRelated', related_name='m2m_through', through=ModelRelatedThrough)
 
-    foreignkey_with_default = models.ForeignKey('ModelRelated', related_name='fk2', null=True, default=default_fk_value, on_delete=models.DO_NOTHING)
-    foreignkey_with_id_default = models.ForeignKey('ModelRelated', related_name='fk3', null=True, default=default_fk_id, on_delete=models.DO_NOTHING)
+    foreignkey_with_default = models.ForeignKey('ModelRelated', related_name='fk2', default=default_fk_value, on_delete=models.DO_NOTHING)
+    foreignkey_with_id_default = models.ForeignKey('ModelRelated', related_name='fk3', default=default_fk_id, on_delete=models.DO_NOTHING)
 
     integer = models.IntegerField(null=True)
     integer_b = models.IntegerField(null=True)
@@ -187,7 +187,7 @@ class ModelWithRelationships(models.Model):
 
 
 class ModelWithCyclicDependency(models.Model):
-    d = models.ForeignKey('ModelWithCyclicDependency2', null=True, on_delete=models.DO_NOTHING)
+    model_b = models.ForeignKey('ModelWithCyclicDependency2', on_delete=models.DO_NOTHING, null=True)
 
     class Meta:
         verbose_name = 'Cyclic dependency'
@@ -195,7 +195,7 @@ class ModelWithCyclicDependency(models.Model):
 
 
 class ModelWithCyclicDependency2(models.Model):
-    c = models.ForeignKey(ModelWithCyclicDependency, null=True, on_delete=models.DO_NOTHING)
+    model_a = models.ForeignKey(ModelWithCyclicDependency, on_delete=models.DO_NOTHING, null=True)
 
     class Meta:
         verbose_name = 'Cyclic dependency 2'
@@ -203,7 +203,7 @@ class ModelWithCyclicDependency2(models.Model):
 
 
 class ModelAbstract(models.Model):
-    integer = models.IntegerField(null=True, unique=True)
+    integer = models.IntegerField(unique=True)
     class Meta:
         abstract = True
         verbose_name = 'Abstract'
@@ -331,7 +331,7 @@ class ModelForCopy(models.Model):
 
 class ModelForLibrary2(models.Model):
     integer = models.IntegerField(null=True)
-    integer_unique = models.IntegerField(null=True, unique=True)
+    integer_unique = models.IntegerField(unique=True)
 
     class Meta:
         verbose_name = 'Library 2'
@@ -340,9 +340,9 @@ class ModelForLibrary2(models.Model):
 
 class ModelForLibrary(models.Model):
     integer = models.IntegerField(null=True)
-    integer_unique = models.IntegerField(null=True, unique=True)
-    selfforeignkey = models.ForeignKey('self', null=True, on_delete=models.DO_NOTHING)
-    foreignkey = models.ForeignKey('ModelForLibrary2', related_name='fk', null=True, on_delete=models.DO_NOTHING)
+    integer_unique = models.IntegerField(unique=True)
+    selfforeignkey = models.ForeignKey('self', on_delete=models.DO_NOTHING, null=True, blank=True)
+    foreignkey = models.ForeignKey('ModelForLibrary2', related_name='fk', on_delete=models.DO_NOTHING)
 
     class Meta:
         verbose_name = 'Library'

--- a/django_dynamic_fixture/models_test.py
+++ b/django_dynamic_fixture/models_test.py
@@ -472,3 +472,34 @@ try:
             raise self.CannotSave
 except ImportError:
     print('Library `django_polymorphic` not installed. Skipping.')
+
+
+# Sample App
+
+class Publisher(models.Model):
+    name = models.CharField(max_length=100, unique=True)
+
+class Author(models.Model):
+    name = models.CharField(max_length=100)
+    description = models.TextField(null=True)
+
+class Category(models.Model):
+    name = models.CharField(max_length=100, unique=True)
+    parent = models.ForeignKey('self', on_delete=models.DO_NOTHING, null=True, blank=True)
+
+class Book(models.Model):
+    isb = models.CharField(max_length=100, unique=True)
+    name = models.CharField(max_length=100)
+    main_author = models.ForeignKey(Author, related_name='books', on_delete=models.DO_NOTHING)
+    authors = models.ManyToManyField('Author', related_name='m2m')
+    categories = models.ManyToManyField('Category', related_name='m2m')
+
+class BookPublisher(models.Model):
+    book_edition = models.ForeignKey('BookEdition', on_delete=models.DO_NOTHING)
+    publisher = models.ForeignKey('Publisher', on_delete=models.DO_NOTHING)
+    comments = models.TextField(max_length=100)
+
+class BookEdition(models.Model):
+    book = models.ForeignKey(Book, related_name='editions', on_delete=models.DO_NOTHING)
+    publishers = models.ManyToManyField('Publisher', related_name='edition_publishers', through=BookPublisher)
+    year = models.IntegerField()

--- a/django_dynamic_fixture/models_test.py
+++ b/django_dynamic_fixture/models_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+# https://docs.djangoproject.com/en/3.0/ref/models/fields
 import django
 from django.conf import settings
 from django.db import models

--- a/django_dynamic_fixture/models_test.py
+++ b/django_dynamic_fixture/models_test.py
@@ -116,6 +116,7 @@ class ModelForNullable(models.Model):
 
 class ModelForIgnoreList2(models.Model):
     nullable = models.IntegerField(null=True)
+    non_nullable = models.IntegerField()
 
     class Meta:
         verbose_name = 'Ignore list 2'

--- a/django_dynamic_fixture/tests/test_ddf.py
+++ b/django_dynamic_fixture/tests/test_ddf.py
@@ -171,7 +171,7 @@ class NewIgnoreFieldsInIgnoreListTest(DDFTestCase):
             self.ddf.get(ModelForIgnoreList)
 
     def test_ignore_fields_are_propagated_to_self_references(self):
-        self.ddf = DynamicFixture(data_fixture, ignore_fields=['not_required'], number_of_laps=1, not_required=10)
+        self.ddf = DynamicFixture(data_fixture, ignore_fields=['not_required'], fk_min_depth=1, not_required=10)
         instance = self.ddf.new(ModelForIgnoreList)
         assert instance.not_required == 10
         assert instance.self_reference is not None
@@ -227,20 +227,20 @@ class NewDealWithSelfReferencesTest(DDFTestCase):
         assert instance.selfforeignkey is None # no cycle
 
     def test_new_create_only_1_lap_in_cycle(self):
-        self.ddf = DynamicFixture(data_fixture, number_of_laps=1)
+        self.ddf = DynamicFixture(data_fixture, fk_min_depth=1)
         instance = self.ddf.new(ModelWithRelationships)
         assert instance.selfforeignkey is not None # 1 cycle
         assert instance.selfforeignkey.selfforeignkey is None # 2 cycles
 
-    def test_new_create_2_laps_in_cycle(self):
-        self.ddf = DynamicFixture(data_fixture, number_of_laps=2)
+    def test_new_create_with_min_depth_2(self):
+        self.ddf = DynamicFixture(data_fixture, fk_min_depth=2)
         instance = self.ddf.new(ModelWithRelationships)
         assert instance.selfforeignkey is not None # 1 cycle
         assert instance.selfforeignkey.selfforeignkey is not None # 2 cycles
         assert instance.selfforeignkey.selfforeignkey.selfforeignkey is None # 3 cycles
 
     def test_number_of_fk_cycles_does_not_break_default_non_null_fk(self):
-        self.ddf = DynamicFixture(data_fixture, number_of_laps=0)
+        self.ddf = DynamicFixture(data_fixture, fk_min_depth=0)
         instance = self.ddf.new(ModelWithRefToParent)
         assert instance.parent is not None
 
@@ -260,7 +260,7 @@ class GetFullFilledModelInstanceAndPersistTest(DDFTestCase):
         assert instance.selfforeignkey is None
         assert instance.foreignkey is not None
         assert instance.onetoone is not None
-        self.ddf = DynamicFixture(data_fixture, number_of_laps=1)
+        self.ddf = DynamicFixture(data_fixture, fk_min_depth=1)
         instance = self.ddf.get(ModelWithRelationships)
         assert instance.selfforeignkey is not None
 
@@ -310,12 +310,12 @@ class NewDealWithCyclicDependenciesTest(DDFTestCase):
         assert a.model_b is None
 
     def test_new_create_only_1_lap_in_fk_cycle(self):
-        self.ddf = DynamicFixture(data_fixture, number_of_laps=1)
+        self.ddf = DynamicFixture(data_fixture, fk_min_depth=1)
         a = self.ddf.get(ModelWithCyclicDependency)
         assert a.model_b.model_a is None
 
-    def test_new_create_n_laps_in_cycle(self):
-        self.ddf = DynamicFixture(data_fixture, number_of_laps=2)
+    def test_new_create_with_min_depth_2(self):
+        self.ddf = DynamicFixture(data_fixture, fk_min_depth=2)
         a = self.ddf.get(ModelWithCyclicDependency)
         assert a.model_b.model_a.model_b is None
 

--- a/django_dynamic_fixture/tests/test_ddf.py
+++ b/django_dynamic_fixture/tests/test_ddf.py
@@ -171,15 +171,17 @@ class NewIgnoreFieldsInIgnoreListTest(DDFTestCase):
             self.ddf.get(ModelForIgnoreList)
 
     def test_ignore_fields_are_propagated_to_self_references(self):
-        self.ddf = DynamicFixture(data_fixture, ignore_fields=['not_required', 'nullable'])
+        self.ddf = DynamicFixture(data_fixture, ignore_fields=['not_required'], number_of_laps=1, not_required=10)
         instance = self.ddf.new(ModelForIgnoreList)
-        assert instance.not_required is None
+        assert instance.not_required == 10
+        assert instance.self_reference is not None
         assert instance.self_reference.not_required is None
 
     def test_ignore_fields_are_not_propagated_to_different_references(self):
-        self.ddf = DynamicFixture(data_fixture, ignore_fields=['not_required', 'nullable'])
+        self.ddf = DynamicFixture(data_fixture, ignore_fields=['non_nullable'], different_reference=DynamicFixture(data_fixture))
         instance = self.ddf.new(ModelForIgnoreList)
-        assert instance.different_reference.nullable is not None
+        assert instance.different_reference is not None
+        assert instance.different_reference.non_nullable is not None
 
     def test_ignore_fields_are_not_ignored_if_explicitely_given(self):
         self.ddf = DynamicFixture(data_fixture, not_required=3, ignore_fields=['not_required', 'nullable'])
@@ -212,23 +214,35 @@ class NewAlsoCreatesRelatedObjectsTest(DDFTestCase):
 
 class NewCanCreatesCustomizedRelatedObjectsTest(DDFTestCase):
     def test_customizing_nullable_fields_for_related_objects(self):
-        instance = self.ddf.new(ModelWithRelationships, selfforeignkey=DynamicFixture(data_fixture, fill_nullable_fields=False))
-        assert isinstance(instance.integer, int)
-        assert instance.selfforeignkey.integer is None
+        instance = self.ddf.new(ModelWithRelationships, selfforeignkey=DynamicFixture(data_fixture, fill_nullable_fields=True))
+        assert instance.integer is None
+        assert isinstance(instance.selfforeignkey.integer, int)
 
 
 class NewDealWithSelfReferencesTest(DDFTestCase):
-    def test_new_create_by_default_only_1_lap_in_cycle(self):
+    def test_new_create_by_default_no_self_fks(self):
+        instance = self.ddf.new(ModelWithRelationships, fill_nullable_fields=False)
+        assert instance.selfforeignkey is None # no cycle
+        instance = self.ddf.new(ModelWithRelationships, fill_nullable_fields=True)
+        assert instance.selfforeignkey is None # no cycle
+
+    def test_new_create_only_1_lap_in_cycle(self):
+        self.ddf = DynamicFixture(data_fixture, number_of_laps=1)
         instance = self.ddf.new(ModelWithRelationships)
         assert instance.selfforeignkey is not None # 1 cycle
         assert instance.selfforeignkey.selfforeignkey is None # 2 cycles
 
-    def test_new_create_n_laps_in_cycle(self):
+    def test_new_create_2_laps_in_cycle(self):
         self.ddf = DynamicFixture(data_fixture, number_of_laps=2)
         instance = self.ddf.new(ModelWithRelationships)
         assert instance.selfforeignkey is not None # 1 cycle
         assert instance.selfforeignkey.selfforeignkey is not None # 2 cycles
-        instance.selfforeignkey.selfforeignkey.selfforeignkey is None # 3 cycles
+        assert instance.selfforeignkey.selfforeignkey.selfforeignkey is None # 3 cycles
+
+    def test_number_of_fk_cycles_does_not_break_default_non_null_fk(self):
+        self.ddf = DynamicFixture(data_fixture, number_of_laps=0)
+        instance = self.ddf.new(ModelWithRefToParent)
+        assert instance.parent is not None
 
 
 class GetFullFilledModelInstanceAndPersistTest(DDFTestCase):
@@ -243,9 +257,12 @@ class GetFullFilledModelInstanceAndPersistTest(DDFTestCase):
 
     def test_get_create_and_save_related_fields(self):
         instance = self.ddf.get(ModelWithRelationships)
-        assert instance.selfforeignkey is not None
+        assert instance.selfforeignkey is None
         assert instance.foreignkey is not None
         assert instance.onetoone is not None
+        self.ddf = DynamicFixture(data_fixture, number_of_laps=1)
+        instance = self.ddf.get(ModelWithRelationships)
+        assert instance.selfforeignkey is not None
 
 
 class ManyToManyRelationshipTest(DDFTestCase):
@@ -288,18 +305,19 @@ class ManyToManyRelationshipTest(DDFTestCase):
 
 
 class NewDealWithCyclicDependenciesTest(DDFTestCase):
-    def test_new_create_by_default_only_1_lap_in_cycle(self):
-        c = self.ddf.new(ModelWithCyclicDependency)
-        assert c.d is not None # 1 cycle
-        assert c.d.c is None # 2 cycles
+    def test_new_create_by_default_no_cycles(self):
+        a = self.ddf.new(ModelWithCyclicDependency)
+        assert a.model_b is None
+
+    def test_new_create_only_1_lap_in_fk_cycle(self):
+        self.ddf = DynamicFixture(data_fixture, number_of_laps=1)
+        a = self.ddf.get(ModelWithCyclicDependency)
+        assert a.model_b.model_a is None
 
     def test_new_create_n_laps_in_cycle(self):
         self.ddf = DynamicFixture(data_fixture, number_of_laps=2)
-        c = self.ddf.new(ModelWithCyclicDependency)
-        assert c.d is not None
-        assert c.d.c is not None # 1 cycle
-        assert c.d.c.d is not None # 2 cycles
-        assert c.d.c.d.c is None # 3 cycles
+        a = self.ddf.get(ModelWithCyclicDependency)
+        assert a.model_b.model_a.model_b is None
 
 
 class NewDealWithInheritanceTest(DDFTestCase):

--- a/django_dynamic_fixture/tests/test_ddf_teaching_and_lessons.py
+++ b/django_dynamic_fixture/tests/test_ddf_teaching_and_lessons.py
@@ -47,7 +47,7 @@ class TeachAndLessonsTest(DDFTestCase):
         # ModelForLibrary.foreignkey is a `ModelForLibrary2`
         self.ddf.teach(ModelForLibrary, integer=1000)
         self.ddf.teach(ModelForLibrary2, integer=1001)
-        instance = self.ddf.get(ModelForLibrary)
+        instance = self.ddf.get(ModelForLibrary, foreignkey=DynamicFixture(data_fixture))
         assert instance.integer == 1000
         assert instance.foreignkey.integer == 1001
 

--- a/django_dynamic_fixture/tests/test_global_settings.py
+++ b/django_dynamic_fixture/tests/test_global_settings.py
@@ -85,18 +85,18 @@ class DDF_IGNORE_FIELDS_TestCase(AbstractGlobalSettingsTestCase):
             reload_module(global_settings)
 
 
-class DDF_NUMBER_OF_LAPS_TestCase(AbstractGlobalSettingsTestCase):
+class DDF_FK_MIN_DEPTH_TestCase(AbstractGlobalSettingsTestCase):
     def test_not_configured_must_load_default_value(self):
         reload_module(global_settings)
-        assert global_settings.DDF_NUMBER_OF_LAPS == 0
+        assert global_settings.DDF_FK_MIN_DEPTH == 0
 
     def test_must_be_an_integer(self):
-        conf.settings.DDF_NUMBER_OF_LAPS = 2
+        conf.settings.DDF_FK_MIN_DEPTH = 2
         reload_module(global_settings)
-        assert global_settings.DDF_NUMBER_OF_LAPS == 2
+        assert global_settings.DDF_FK_MIN_DEPTH == 2
 
     def test_must_raise_an_exception_if_it_is_not_an_integer(self):
-        conf.settings.DDF_NUMBER_OF_LAPS = None
+        conf.settings.DDF_FK_MIN_DEPTH = None
         with pytest.raises(Exception):
             reload_module(global_settings)
 

--- a/django_dynamic_fixture/tests/test_sample_app.py
+++ b/django_dynamic_fixture/tests/test_sample_app.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from django.test import TestCase
+
+from ddf import *
+
+
+class SampleAppTestCase(TestCase):
+    def test_publisher(self):
+        o = G('django_dynamic_fixture.Publisher')
+        assert o.name is not None
+
+    def test_author(self):
+        o = G('django_dynamic_fixture.Author')
+        assert o.name is not None
+        assert o.description is None
+        o = G('django_dynamic_fixture.Author', fill_nullable_fields=True)
+        assert o.description is not None
+
+    def test_category(self):
+        o = G('django_dynamic_fixture.Category')
+        assert o.name is not None
+        assert o.parent is None
+        o = G('django_dynamic_fixture.Category', fk_min_depth=1)
+        assert o.parent is not None
+        assert o.parent.parent is None
+        o = G('django_dynamic_fixture.Category', fk_min_depth=2)
+        assert o.parent.parent is not None
+        assert o.parent.parent.parent is None
+
+    def test_book(self):
+        o = G('django_dynamic_fixture.Book')
+        assert o.main_author is not None
+        assert o.main_author.name is not None
+        assert o.authors.all().count() == 0
+        assert o.categories.all().count() == 0
+        o = G('django_dynamic_fixture.Book', authors=2, categories=5)
+        assert o.authors.all().count() == 2
+        assert o.categories.all().count() == 5
+
+    def test_book_edition(self):
+        o = G('django_dynamic_fixture.BookEdition')
+        assert o.book is not None
+        assert o.year is not None
+        assert o.publishers.all().count() == 0
+        o = G('django_dynamic_fixture.BookEdition', publishers=2)
+        assert o.publishers.all().count() == 2
+
+    def test_book_publisher(self):
+        o = G('django_dynamic_fixture.BookPublisher')
+        assert o.book_edition.book is not None
+        assert o.publisher is not None
+        assert o.comments is not None

--- a/docs/source/data.rst
+++ b/docs/source/data.rst
@@ -105,22 +105,24 @@ It is not possible to override the global configuration, just extend the list. S
     assert instance.another_field_name is None
 
 
-Number of Laps/Cycles
+Minimum Foreign Key Depth
 ===============================================================================
 
-This option is used by DDF to control cyclic dependencies (``ForeignKey`` by ``self``, denormalizations, bad design etc). DDF does not enter infinite loop of instances generation. This option defines how many laps DDF will create for each cyclic dependency. This option can also be used to create trees with different lengths.
+This option is used by DDF to control dependencies and cyclic dependencies (``ForeignKey`` by ``self``, denormalizations, bad design etc). DDF does not enter infinite loop of instances generation. This option defines how depth DDF should go to create instances of foreign key fields. This option can also be used to create trees with different lengths.
 
 In settings.py::
 
-    DDF_NUMBER_OF_LAPS = 1
+    DDF_FK_MIN_DEPTH = 0
 
 In the test file::
 
-    instance = G(MyModel, number_of_laps=1)
+    instance = G(MyModel, fk_min_depth=1)
     assert instance.self_fk.id is not None
     assert instance.self_fk.self_fk.id is None
 
-    instance = G(MyModel, number_of_laps=2)
+    instance = G(MyModel, fk_min_depth=2)
     assert instance.self_fk.id is not None
     assert instance.self_fk.self_fk.id is not None
     assert instance.self_fk.self_fk.self_fk.id is None
+
+> Incompatibility warning: Before DDF 3.0.3, DDF handled FK cycles instead of FK depth, through the removed properties `DDF_NUMBER_OF_LAPS` and `number_of_laps`.

--- a/docs/source/data.rst
+++ b/docs/source/data.rst
@@ -67,7 +67,7 @@ About Custom Fields
 Fill Nullable Fields
 ===============================================================================
 
-This option define if nullable fields (fields with ``null=True``) will receive a generated data or not (``data=None``). It is possible to override the global option for an specific instance. But be careful because this option will be propagate to all internal dependencies.
+This option define if nullable fields (fields with ``null=True``) will receive a generated data or not (``data=None``). This property is exclusive for non-FK fields. It is possible to override the global option for an specific instance. But be careful because this option will be propagate to all internal dependencies.
 
 In settings.py::
 

--- a/docs/source/patterns.rst
+++ b/docs/source/patterns.rst
@@ -15,7 +15,7 @@ Patterns
   * Use custom values for unsupported fields.
   * Use default lesson for unsupported fields with a custom function that generated data.
   * Use *fill_nullable_fields* for unsupported nullable fields.
-  * Use *number_of_laps* option to test trees.
+  * Use *fk_min_depth* option to test trees.
   * [Automated Test Patterns](http://www.teses.usp.br/teses/disponiveis/45/45134/tde-02042012-120707/pt-br.php) (in Portuguese)
 
 Anti-Patterns

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -38,10 +38,12 @@ You can configure DDF in ``settings.py`` file. You can also override the global 
     DDF_FIELD_FIXTURES = {'path.to.your.Field': lambda: random.randint(0, 10) }
 
 
-* **DDF_NUMBER_OF_LAPS** (Default = 0):  For models with foreign keys to itself (``ForeignKey('self')``), DDF will avoid infinite loops because it stops creating objects after it create **n** **laps** for the cycle::
+* **DDF_FK_MIN_DEPTH** (Default = 0):  For models with non required foreign keys (FKs with `null=True`), like FKs to itself (``ForeignKey('self')``), cyclic dependencies or even optional FKs, DDF will avoid infinite loops because it stops creating objects indefinetely, because it will stop after the min depth was achieved.::
 
     # You can override the global config for one case:
-    G(Model, number_of_laps=5)
+    G(Model, fk_min_depth=5)
+
+> Incompatibility warning: Before DDF 3.0.3, DDF handled FK cycles instead of FK depth, through the removed properties `DDF_NUMBER_OF_LAPS` and `number_of_laps`.
 
 
 * **DDF_DEBUG_MODE** (Default = False): To show some DDF logs::

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,6 @@ nose-progressive>=1.5
 geopy
 
 # 3rd party libraries
-jsonfield
+# jsonfield>=2.1.1
 django-json-field
 django-polymorphic


### PR DESCRIPTION
Number of laps was bugged when the value was 0.
Removed this property and added a new `DDF_FK_MIN_DEPTH`, or `fk_min_depth` property to fix this issue:
https://github.com/paulocheque/django-dynamic-fixture/issues/120

Priority for Default value instead of Null values:
https://github.com/paulocheque/django-dynamic-fixture/issues/121