### PR TITLE
docs: Fix simple typo, enviroment -> environment

### DIFF
--- a/django_dynamic_fixture/fixture_algorithms/default_fixture.py
+++ b/django_dynamic_fixture/fixture_algorithms/default_fixture.py
@@ -18,7 +18,7 @@ except ImportError:
 try:
     from django.contrib.gis.geos import *
 except ImproperlyConfigured:
-    pass  # enviroment without geo libs
+    pass  # environment without geo libs
 except Exception:
     pass # Avoid errors like GDALException
 

--- a/django_dynamic_fixture/fixture_algorithms/random_fixture.py
+++ b/django_dynamic_fixture/fixture_algorithms/random_fixture.py
@@ -16,7 +16,7 @@ except ImportError:
 try:
     from django.contrib.gis.geos import *
 except ImproperlyConfigured:
-    pass  # enviroment without geo libs
+    pass  # environment without geo libs
 except Exception:
     pass # Avoid errors like GDALException
 

--- a/django_dynamic_fixture/fixture_algorithms/sequential_fixture.py
+++ b/django_dynamic_fixture/fixture_algorithms/sequential_fixture.py
@@ -15,7 +15,7 @@ except ImportError:
 try:
     from django.contrib.gis.geos import *
 except ImproperlyConfigured:
-    pass  # enviroment without geo libs
+    pass  # environment without geo libs
 except Exception:
     pass # Avoid errors like GDALException
 

--- a/django_dynamic_fixture/fixture_algorithms/tests/test_default_fixture.py
+++ b/django_dynamic_fixture/fixture_algorithms/tests/test_default_fixture.py
@@ -12,7 +12,7 @@ from django.contrib.gis.geos import *
 try:
     from django.contrib.gis.db import models as geomodels
 except ImproperlyConfigured:
-    pass  # enviroment without geo libs
+    pass  # environment without geo libs
 
 
 from django.test import TestCase

--- a/django_dynamic_fixture/fixture_algorithms/unique_random_fixture.py
+++ b/django_dynamic_fixture/fixture_algorithms/unique_random_fixture.py
@@ -20,7 +20,7 @@ except ImportError:
 try:
     from django.contrib.gis.geos import *
 except ImproperlyConfigured:
-    pass  # enviroment without geo libs
+    pass  # environment without geo libs
 except Exception:
     pass # Avoid errors like GDALException
 

--- a/django_dynamic_fixture/tests/test_ddf_geo.py
+++ b/django_dynamic_fixture/tests/test_ddf_geo.py
@@ -5,12 +5,12 @@ from django.core.exceptions import ImproperlyConfigured
 try:
     from django.contrib.gis.geos import *
 except ImproperlyConfigured:
-    pass  # enviroment without geo libs
+    pass  # environment without geo libs
 
 try:
     from django.contrib.gis.db import models as geomodel
 except ImproperlyConfigured:
-    pass  # enviroment without geo libs
+    pass  # environment without geo libs
 
 from django.test import TestCase
 import pytest


### PR DESCRIPTION
There is a small typo in django_dynamic_fixture/fixture_algorithms/default_fixture.py, django_dynamic_fixture/fixture_algorithms/random_fixture.py, django_dynamic_fixture/fixture_algorithms/sequential_fixture.py, django_dynamic_fixture/fixture_algorithms/tests/test_default_fixture.py, django_dynamic_fixture/fixture_algorithms/unique_random_fixture.py, django_dynamic_fixture/tests/test_ddf_geo.py.

Should read `environment` rather than `enviroment`.

