### PR TITLE
Correct type for TimeField

### DIFF
--- a/django_dynamic_fixture/fixture_algorithms/random_fixture.py
+++ b/django_dynamic_fixture/fixture_algorithms/random_fixture.py
@@ -85,7 +85,7 @@ class RandomDataFixture(BaseDataFixture, GeoDjangoFixtureMixin, PostgresFixtureM
         return date.today() - timedelta(days=random.randint(1, 36500))
 
     def timefield_config(self, field, key):
-        return now() - timedelta(seconds=random.randint(1, 36500))
+        return (now() - timedelta(seconds=random.randint(1, 36500))).time()
 
     def datetimefield_config(self, field, key):
         return now() - timedelta(seconds=random.randint(1, 36500))

--- a/django_dynamic_fixture/fixture_algorithms/sequential_fixture.py
+++ b/django_dynamic_fixture/fixture_algorithms/sequential_fixture.py
@@ -118,7 +118,7 @@ class SequentialDataFixture(BaseDataFixture, GeoDjangoFixtureMixin, PostgresFixt
 
     def timefield_config(self, field, key):
         data = self.get_value(field, key)
-        return now() - timedelta(seconds=data)
+        return (now() - timedelta(seconds=data)).time()
 
     def datetimefield_config(self, field, key):
         data = self.get_value(field, key)

--- a/django_dynamic_fixture/fixture_algorithms/tests/abstract_test_generic_fixture.py
+++ b/django_dynamic_fixture/fixture_algorithms/tests/abstract_test_generic_fixture.py
@@ -2,7 +2,7 @@
 
 from django.db import models
 
-from datetime import datetime, date
+from datetime import datetime, date, time
 from decimal import Decimal
 import six
 
@@ -43,7 +43,7 @@ class DataFixtureTestCase(object):
 
     def test_date_time_related(self):
         assert isinstance(self.fixture.generate_data(models.DateField()), date)
-        assert isinstance(self.fixture.generate_data(models.TimeField()), datetime)
+        assert isinstance(self.fixture.generate_data(models.TimeField()), time)
         assert isinstance(self.fixture.generate_data(models.DateTimeField()), datetime)
 
     def test_formatted_strings(self):

--- a/django_dynamic_fixture/fixture_algorithms/unique_random_fixture.py
+++ b/django_dynamic_fixture/fixture_algorithms/unique_random_fixture.py
@@ -141,7 +141,7 @@ class UniqueRandomDataFixture(BaseDataFixture, GeoDjangoFixtureMixin, PostgresFi
 
     def timefield_config(self, field, key):
         integer = self.random_integer(field, key, signed=False)
-        return now() - timedelta(seconds=integer)
+        return (now() - timedelta(seconds=integer)).time()
 
     def datetimefield_config(self, field, key):
         integer = self.random_integer(field, key, signed=False)

--- a/django_dynamic_fixture/tests/test_ddf.py
+++ b/django_dynamic_fixture/tests/test_ddf.py
@@ -68,7 +68,7 @@ class NewFullFillAttributesWithAutoDataTest(DDFTestCase):
     def test_new_fill_time_related_fields_with_current_values(self):
         instance = self.ddf.new(ModelWithDateTimes)
         assert date.today() >= instance.date
-        assert datetime.now() >= instance.time
+        assert datetime.now().time() >= instance.time
         assert datetime.now() >= instance.datetime
 
     def test_new_fill_formatted_strings_fields_with_basic_values(self):


### PR DESCRIPTION
When creating a fixture for a TimeField the return should be a datetime.time instance rather than a datetime.datetime instance as currently