### PR TITLE
Prevent deprecation warnings for distutils StrictVersion when running with setuptools or Python >= 3.10

### DIFF
--- a/django_dynamic_fixture/__init__.py
+++ b/django_dynamic_fixture/__init__.py
@@ -23,8 +23,8 @@ from django_dynamic_fixture.script_ddf_checkings import ddf_check_models
 __version__ = '3.1.2'
 
 
-if not django_greater_than('1.10'):
-    warnings.warn("DDF supports oficially only Django 1.11 or higher.", DeprecationWarning)
+if not django_greater_than(1, 10):
+    warnings.warn("DDF officially supports only Django 1.11 or higher.", DeprecationWarning)
 
 
 LOOKUP_SEP = '__'
@@ -213,4 +213,3 @@ T = teach
         exec(hack_to_avoid_py2_syntax_errors)
     except (ImportError, SyntaxError) as e:
         pass
-

--- a/django_dynamic_fixture/django_helper.py
+++ b/django_dynamic_fixture/django_helper.py
@@ -2,9 +2,6 @@
 """
 Module to wrap dirty stuff of django core.
 """
-import re
-from distutils.version import StrictVersion
-
 import django
 from django.apps import apps
 from django.db import models  # noqa
@@ -18,11 +15,9 @@ except ImportError:
     from django.core.exceptions import FieldDoesNotExist
 
 
+def django_greater_than(major, minor=0):
+    return django.VERSION[:2] > (major, minor)
 
-def django_greater_than(version):
-    # Avoid StrictVersion errors with versions like 1.8c1
-    DJANGO_VERSION = re.match(r"\d\.\d\d?", django.get_version()).group(0)
-    return StrictVersion(DJANGO_VERSION) >= StrictVersion(version)
 
 # Apps
 def get_apps(application_labels=[], exclude_application_labels=[]):


### PR DESCRIPTION
Using `distutils.version.StrictVersion` raises a deprecation warning when running with [`setuptools` >= 59.6.0](https://github.com/pypa/setuptools/commit/1701579e0827317d8888c2254a17b5786b6b5246) (2021-12-12) or Python >= 3.10 ([PEP 632](https://peps.python.org/pep-0632/)).

So instead of messing around with regular expressions and `StrictVersion` this pull request numerically compares the first two version parts of [`django.VERSION`](https://github.com/django/django/blob/main/django/__init__.py#L3), which has been around since [Django 0.9.1](https://github.com/django/django/blob/d5dbeaa9be359a4c794885c2e9f1b5a7e5e51fb8/django/__init__.py) (2006-02-17) and seems to always have at least to integer components.

However, this _will_ break clients that use `django_greater_than()` themselves (is this part of DDF's public interface?). If this is a concern, I could check if the `major` argument is a string and attempt to split it into integers, maybe raising another deprecation warning in the process.

Alternatively, I could try to import [`packaging.version.Version`](https://github.com/pypa/packaging/blob/main/packaging/version.py) and fall back to `distutils.version.StrictVersion` if `packaging` cannot be imported. But I really like the numeric approach here :)