### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -45,7 +45,7 @@ TODO list
 Tests and Bugfixes
 -------------------------------------------------------------------------------
 * with_queries bugfixes (always print 0 queries)
-* Deal with relatioships with dynamic related_name
+* Deal with relationships with dynamic related_name
 * bugfix in fdf or ddf: some files/directories are not deleted
 * tests with files in ddf
 * tests with proxy models

--- a/docs/source/ddf.rst
+++ b/docs/source/ddf.rst
@@ -21,7 +21,7 @@ It receives a model class and it will return a **valid and persisted instance** 
     assert len(author.name) > 0
 
 
-This facilitates writing tests and it hides all dummy data that polutes the source code. But all **important data of the test may be explicitily defined**. This is even a good practice, because it let the test very clear and cohesive::
+This facilitates writing tests and it hides all dummy data that pollutes the source code. But all **important data of the test may be explicitly defined**. This is even a good practice, because it let the test very clear and cohesive::
 
 
     book = G(Book, name='The Lord of the Rings', publish_date=date(1954, 07, 29))

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,9 +8,9 @@ Welcome to DDF's documentation!
 
 Django Dynamic Fixture (DDF) is a complete and simple library to create **dynamic model instances** for **testing purposes**.
 
-It lets you **focus on your tests**, instead of focusing on generating some dummy data which is boring and polutes the test source code.
+It lets you **focus on your tests**, instead of focusing on generating some dummy data which is boring and pollutes the test source code.
 
-It exists to solve the **anti-pattern** of Static Fixtures and Factory objects. Are you tired to mantain dozens of yml/json files and factory objects?
+It exists to solve the **anti-pattern** of Static Fixtures and Factory objects. Are you tired to maintain dozens of yml/json files and factory objects?
 
 
 .. toctree::

--- a/docs/source/more.rst
+++ b/docs/source/more.rst
@@ -123,7 +123,7 @@ In the test file::
 Signals PRE_SAVE and POST_SAVE:
 ===============================================================================
 
-In very special cases a signal may facilitate implementing tests with DDF, but Django signals may not be satisfatory for testing pourposes because the developer does not have control of the execution order of the receivers. For this reason, DDF provides its own signals. It is possible to have only one receiver for each model, to avoid anti-patterns::
+In very special cases a signal may facilitate implementing tests with DDF, but Django signals may not be satisfactory for testing purposes because the developer does not have control of the execution order of the receivers. For this reason, DDF provides its own signals. It is possible to have only one receiver for each model, to avoid anti-patterns::
 
     from django_dynamic_fixture import PRE_SAVE, POST_SAVE
     def callback_function(instance):

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -136,7 +136,7 @@ Motivation
 ===============================================================================
 
   * It is a terrible practice to use **static data** in tests (yml/json/sql files).
-  * It is very hard to mantain lots of **Factory objects**.
+  * It is very hard to maintain lots of **Factory objects**.
   * Creating fixtures for each model is boring and it produces a lot of **replicated code**.
   * It is a bad idea to use uncontrolled data in tests, like bizarre random data.
 
@@ -150,7 +150,7 @@ Another thing, the DDF was planned to have a **lean and clean syntax**. We belie
 Also, DDF is flexible, since it is possible to customize the entire data generation or by field.
 
   * Either they are incomplete, or bugged or it produces erratic tests, because they use random and uncontrolled data.
-  * The syntax of others tools is too verbose, which polutes the tests.
+  * The syntax of others tools is too verbose, which pollutes the tests.
   * Complete, lean and practice documentation.
   * It is hard to debug tests with another tools.
   * List of other tools: <https://www.djangopackages.com/grids/g/testing/> or <http://djangopackages.com/grids/g/fixtures>

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -38,7 +38,7 @@ You can configure DDF in ``settings.py`` file. You can also override the global 
     DDF_FIELD_FIXTURES = {'path.to.your.Field': lambda: random.randint(0, 10) }
 
 
-* **DDF_FK_MIN_DEPTH** (Default = 0):  For models with non required foreign keys (FKs with `null=True`), like FKs to itself (``ForeignKey('self')``), cyclic dependencies or even optional FKs, DDF will avoid infinite loops because it stops creating objects indefinetely, because it will stop after the min depth was achieved.::
+* **DDF_FK_MIN_DEPTH** (Default = 0):  For models with non required foreign keys (FKs with `null=True`), like FKs to itself (``ForeignKey('self')``), cyclic dependencies or even optional FKs, DDF will avoid infinite loops because it stops creating objects indefinitely, because it will stop after the min depth was achieved.::
 
     # You can override the global config for one case:
     G(Model, fk_min_depth=5)
@@ -53,4 +53,4 @@ You can configure DDF in ``settings.py`` file. You can also override the global 
     G(Model, debug_mode=False)
 
 
-* **DDF_SHELL_MODE** (Default = False): To disable some DDF warnings so DDF can be used better in Python shell: to populate the DB, for exampel.
+* **DDF_SHELL_MODE** (Default = False): To disable some DDF warnings so DDF can be used better in Python shell: to populate the DB, for example.


### PR DESCRIPTION
There are small typos in:
- docs/source/about.rst
- docs/source/ddf.rst
- docs/source/index.rst
- docs/source/more.rst
- docs/source/overview.rst
- docs/source/settings.rst

Fixes:
- Should read `pollutes` rather than `polutes`.
- Should read `maintain` rather than `mantain`.
- Should read `satisfactory` rather than `satisfatory`.
- Should read `relationships` rather than `relatioships`.
- Should read `purposes` rather than `pourposes`.
- Should read `indefinitely` rather than `indefinetely`.
- Should read `explicitly` rather than `explicitily`.
- Should read `example` rather than `exampel`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md