### PR TITLE
Allow `Mask` objects as lessons for unique fields

### DIFF
--- a/django_dynamic_fixture/ddf.py
+++ b/django_dynamic_fixture/ddf.py
@@ -685,7 +685,10 @@ class DynamicFixture(object):
             if field_name in self._DDF_CONFIGS:
                 continue
             field = get_field_by_name_or_raise(model_class, field_name)
-            fixture = kwargs[field_name]
-            if field.unique and not (isinstance(fixture, (DynamicFixture, Copier, DataFixture)) or callable(fixture)):
+            if field.unique and not _is_dynamic_value(kwargs[field_name]):
                 raise InvalidConfigurationError('It is not possible to store static values for fields with unique=True (%s). Try using a lambda function instead.' % get_unique_field_name(field))
         library.add_configuration(model_class, kwargs, name=ddf_lesson)
+
+
+def _is_dynamic_value(fixture):
+    return isinstance(fixture, (DynamicFixture, Copier, DataFixture, Mask)) or callable(fixture)

--- a/django_dynamic_fixture/fixture_algorithms/tests/test_default_fixture.py
+++ b/django_dynamic_fixture/fixture_algorithms/tests/test_default_fixture.py
@@ -8,8 +8,8 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
 
-from django.contrib.gis.geos import *
 try:
+    from django.contrib.gis.geos import *
     from django.contrib.gis.db import models as geomodels
 except ImproperlyConfigured:
     pass  # environment without geo libs

--- a/django_dynamic_fixture/models_test.py
+++ b/django_dynamic_fixture/models_test.py
@@ -353,6 +353,14 @@ class ModelForLibrary(models.Model):
         app_label = 'django_dynamic_fixture'
 
 
+class ModelWithUniqueCharField(models.Model):
+    text_unique = models.CharField(max_length=20, unique=True)
+
+    class Meta:
+        verbose_name = 'Unique char field'
+        app_label = 'django_dynamic_fixture'
+
+
 class ModelForDDFSetup(models.Model):
     integer = models.IntegerField(null=True)
 

--- a/django_dynamic_fixture/tests/test_ddf_teaching_and_lessons.py
+++ b/django_dynamic_fixture/tests/test_ddf_teaching_and_lessons.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import re
+
 from django.test import TestCase
 import pytest
 
@@ -36,6 +38,16 @@ class TeachAndLessonsTest(DDFTestCase):
     def test_it_must_raise_an_error_if_try_to_set_a_static_value_to_a_field_with_unicity(self):
         with pytest.raises(InvalidConfigurationError):
             self.ddf.teach(ModelForLibrary, integer_unique=1000)
+
+    def test_it_allows_to_use_masks_as_lessons_for_unique_integer_fields(self):
+        self.ddf.teach(ModelForLibrary, integer_unique=Mask('1###'))
+        instance = self.ddf.get(ModelForLibrary)
+        assert 1000 <= int(instance.integer_unique) <= 1999
+
+    def test_it_allows_to_use_masks_as_lessons_for_unique_char_fields(self):
+        self.ddf.teach(ModelWithUniqueCharField, text_unique=Mask('---- ### __'))
+        instance = self.ddf.get(ModelWithUniqueCharField)
+        assert re.match(r'[A-Z]{4} [0-9]{3} [a-z]{2}', instance.text_unique)
 
     def test_it_must_accept_dynamic_values_for_fields_with_unicity(self):
         self.ddf.teach(ModelForLibrary, integer_unique=lambda field: 1000)


### PR DESCRIPTION
Fixes #152.

It's technically possible to use `Mask('#####')` on integer fields because Django will convert the string to an integer when saving the model to the database. However, the model instance keeps the string value which makes working with those fields afterwards pretty awkward...