### PR TITLE
Update `G` functions return type to include lists if `n` argument is used

### DIFF
--- a/django_dynamic_fixture/__init__.py
+++ b/django_dynamic_fixture/__init__.py
@@ -194,7 +194,7 @@ INSTANCE_TYPE = typing.TypeVar('INSTANCE')
 def new(model: typing.Type[INSTANCE_TYPE], n: int = 1, ddf_lesson = None, persist_dependencies: bool = True, **kwargs) -> INSTANCE_TYPE:
     return _new(model, n=n, ddf_lesson=ddf_lesson, persist_dependencies=persist_dependencies, **kwargs)
 
-def get(model: typing.Type[INSTANCE_TYPE], n: int=1, ddf_lesson=None, **kwargs) -> INSTANCE_TYPE:
+def get(model: typing.Type[INSTANCE_TYPE], n: int=1, ddf_lesson=None, **kwargs) -> INSTANCE_TYPE | typing.List[INSTANCE_TYPE]:
     return _get(model, n=n, ddf_lesson=ddf_lesson, **kwargs)
 
 def teach(model: typing.Type[INSTANCE_TYPE], ddf_lesson=None, **kwargs):


### PR DESCRIPTION
This fixes the typing issue in: https://github.com/paulocheque/django-dynamic-fixture/issues/163




Glad to make any other changes that would be needed.